### PR TITLE
feat: add per-token password authentication support

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,147 @@
+# CodeRabbit Configuration for WStunnel
+# This configuration aligns with the project's code quality standards and conventions
+
+# Core settings
+language: "en-US"
+early_access: false
+
+# Tools configuration
+reviews:
+  # Enable relevant tools for Go project
+  tools:
+    golangci-lint:
+      enabled: true
+
+    # Enable other relevant tools
+    languagetool:
+      enabled: true
+
+    shellcheck:
+      enabled: true
+
+    markdownlint:
+      enabled: true
+
+    # AST-based custom rules
+    ast-grep:
+      essential_rules: true
+
+    # Additional tools specific to this project
+    github-actions:
+      enabled: true
+
+    osv-scanner:
+      enabled: true
+
+    codeql:
+      enabled: true
+
+    hadolint:
+      enabled: true
+
+    yamllint:
+      enabled: true
+
+    gitleaks:
+      enabled: true
+
+  # Review profile - use assertive for thorough reviews
+  profile: "assertive"
+
+  # Path filters - exclude certain paths from review
+  path_filters:
+    - "!vendor/**"
+    - "!build/**"
+    - "!node_modules/**"
+    - "!**/*.pb.go"
+    - "!**/generated/**"
+    - "!coverage.txt"
+    - "!CLAUDE.md"
+    - "!.cursor-*"
+    - "!.aider*"
+    - "!.continue/**"
+
+  # File path instructions for Go-specific guidance
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        - Ensure code follows gofmt formatting standards
+        - Check that imports are properly organized (standard library first, third-party after)
+        - Verify error handling follows the pattern: check immediately, return or log with context
+        - Ensure logging uses log15 with structured key-value pairs
+        - Verify naming conventions: PascalCase for exported, camelCase for unexported
+        - Check for unhandled errors
+        - Verify proper use of contexts
+
+    - path: "tunnel/**/*.go"
+      instructions: |
+        - Check WebSocket handling follows established patterns in tunnel/ws.go
+        - Verify concurrent request handling uses goroutine-per-request pattern
+        - Check for security issues: no logging of passwords/tokens, proper certificate validation
+        - Ensure no unused blank identifiers (like `var _ fmt.Formatter`)
+        - Verify token authentication is properly implemented
+        - Check for timing attacks in authentication
+        - Ensure errors don't leak sensitive information
+
+    - path: "**/*_test.go"
+      instructions: |
+        - Confirm tests follow standard Go testing patterns
+        - Verify test coverage for edge cases and error conditions
+        - Prefer table-driven tests
+        - Test both success and error paths
+        - Mock external dependencies appropriately
+
+    - path: "go.mod"
+      instructions: |
+        - Ensure go.mod uses correct format (e.g., `go 1.24` not `go 1.24.0`)
+
+    - path: "whois/**"
+      instructions: |
+        - This is WHOIS lookup functionality
+        - Verify proper error handling for network operations
+        - Check for proper context usage in API calls
+
+  # Auto review configuration
+  auto_review:
+    drafts: true
+    labels:
+      - "WIP"
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "DRAFT"
+
+# Review behavior configuration
+review_status:
+  # Auto-resolve outdated comments when code is updated
+  auto_resolve_conversations: true
+
+  # Don't block merges on outdated review comments
+  block_merge_on_unresolved_conversations: false
+
+  # Only block merges for current/active issues
+  dismiss_stale_reviews: true
+
+  # Handle force pushes and amended commits gracefully
+  handle_force_push: true
+
+  # Automatically mark conversations as resolved when the problematic code is removed/fixed
+  # This is especially useful for amended commits
+  resolve_on_fix: true
+
+  # Don't re-review unchanged files after force push
+  skip_unchanged_files: true
+
+# Auto-approve configuration
+auto_approve:
+  # Dependency updates from Renovate
+  - author: "renovate[bot]"
+    files:
+      - "go.mod"
+      - "go.sum"
+
+  # Documentation-only changes
+  - files:
+      - "**/*.md"
+      - "docs/**"
+    require_review_from_owner: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Add
+
+* Add support for per-token passwords for enhanced security (#50)
+  - Server: Use `-passwords 'token1:password1,token2:password2'` to require passwords for specific tokens
+  - Client: Use `-token 'mytoken:mypassword'` to authenticate with a password
+
 ### Fix
 
 * Fix timeout of requests to _token endpoint (#3)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Project Overview
+WStunnel is a WebSocket-based reverse HTTP/HTTPS tunneling solution that enables access to services behind firewalls. It consists of:
+- **wstunsrv**: Server component that runs on public internet, receives HTTP requests
+- **wstuncli**: Client component that runs behind firewall, connects to server via WebSocket
+- Token-based routing allows multiple clients to connect to a single server
+- Supports authentication, proxies, SSL/TLS, concurrent requests, and health monitoring
+
 ## Build Commands
 - `make` - Build for local OS/arch
 - `make build` - Build for linux/amd64, windows/amd64
@@ -26,6 +33,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Blank Identifiers**: Don't use unused blank identifiers like `var _ fmt.Formatter`
 - **Go Version**: Use `go 1.24` format in go.mod (not `go 1.24.0`)
 
+## Architecture Patterns
+- **Goroutine per request**: Each HTTP request gets its own goroutine for concurrent handling
+- **Request IDs**: 16-bit IDs enable multiplexing multiple requests over single WebSocket
+- **WebSocket protocol**: Uses gorilla/websocket for reliable WebSocket implementation
+- **Reverse proxy pattern**: Server forwards requests through persistent tunnel to client
+
+## Key Files
+- `main.go` - Entry point, determines server vs client mode
+- `tunnel/wstunsrv.go` - Server implementation (accepts HTTP, forwards via WebSocket)
+- `tunnel/wstuncli.go` - Client implementation (connects WebSocket, forwards to local HTTP)
+- `tunnel/ws.go` - WebSocket handling, message types, connection management
+- `tunnel/log.go` - Logging configuration and setup
+
+## Testing Approach
+- Integration tests use actual HTTP servers and tunnel components
+- Tests cover authentication, proxies, failures, timeouts, concurrent requests
+- Use `testutil.TestLogLevel()` to control log verbosity in tests
+- Port allocation uses `:0` to get random available ports
+
+## Security Considerations
+- Tokens must be at least 16 characters
+- Optional password authentication per token
+- Certificate validation for SSL/TLS connections
+- X-Host header validation with regex whitelist
+- Never log sensitive information like passwords or tokens
+
 ## Version Control
 - Create version.go with `make version`
 - Update CHANGELOG.md with `make changelog`
@@ -34,3 +67,5 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - If you encounter linting errors with `golangci-lint run`, check for unused declarations
 - Go version in go.mod should be `go 1.24` (not `go 1.24.0`)
 - The application has no `-version` flag, check version in the generated `version.go` file
+- WebSocket ping/pong failures often indicate network issues or proxy interference
+- Request timeouts can be tuned with `-timeout` flag (default 30s)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WStunnel - Web Sockets Tunnel
 
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/rshade/wstunnel?utm_source=oss&utm_medium=github&utm_campaign=rshade%2Fwstunnel&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+
 - Master:
 [![Build Status](https://travis-ci.org/rightscale/wstunnel.svg?branch=master)](https://travis-ci.org/rightscale/wstunnel)
 [![Coverage](https://s3.amazonaws.com/rs-code-coverage/wstunnel/cc_badge_master.svg)](https://gocover.io/github.com/rightscale/wstunnel)
@@ -101,6 +103,12 @@ WSTUNSRV RUNNING
 $
 ```
 
+To require passwords for specific tokens, use the `-passwords` option:
+
+```bash
+$ ./wstunnel srv -port 8080 -passwords 'token1:password1,token2:password2' &
+```
+
 ### Start tunnel
 
 On `www.example.com` verify that you can access the local web site:
@@ -116,6 +124,26 @@ Now set-up the tunnel:
 $ ./wstunnel cli -tunnel ws://wstun.example.com:8080 -server http://localhost -token 'my_b!g_$secret!!'
 2014/01/19 09:54:51 Opening ws://wstun.example.com/_tunnel
 ```
+
+To use a token with a password for additional security:
+
+```bash
+$ ./wstunnel cli -tunnel ws://wstun.example.com:8080 -server http://localhost -token 'my_b!g_$secret!!:mypassword'
+```
+
+> **Security Warning**: Passing passwords via command-line arguments is not recommended as they can be exposed through:
+> - Process listings (visible to other users on the system)
+> - Shell history files
+> - System logs and crash dumps
+> - Command-line argument inspection tools
+>
+> Instead, consider these more secure alternatives:
+> - Use environment variables: `WSTUNNEL_PASSWORD=mypassword ./wstunnel cli ...`
+> - Store credentials in a configuration file with restricted permissions
+> - Use interactive password prompts (not yet implemented)
+> - Use a secrets management service
+>
+> The same warning applies to the `-passwords` option on the server side.
 
 ### Make a request through the tunnel
 

--- a/claude_prompts/product_manager.md
+++ b/claude_prompts/product_manager.md
@@ -1,0 +1,102 @@
+# WStunnel Product Manager Prompt
+
+You are acting as a Product Manager for WStunnel, an open-source WebSocket-based reverse HTTP/HTTPS tunneling solution. Your role is to help prioritize features, manage the product roadmap, analyze user needs, and guide the technical direction of the project.
+
+## Product Context
+
+WStunnel solves the critical problem of accessing services behind corporate firewalls without requiring inbound firewall rules or complex VPN setups. It's particularly valuable for:
+- IoT device connectivity
+- Remote access to internal services
+- Development and testing environments
+- Bypassing restrictive network policies
+- Creating secure tunnels for microservices
+
+The product consists of two main components:
+1. **wstunsrv** - Server component that runs on the public internet
+2. **wstuncli** - Client component that runs behind firewalls
+
+## Current Product State
+
+### Core Features
+- Token-based routing for multi-tenancy
+- Optional password authentication per token
+- Full proxy support (HTTP/HTTPS)
+- SSL/TLS encryption
+- Concurrent request handling
+- Health monitoring endpoints
+- Automatic reconnection and retry logic
+
+### Technical Stack
+- Written in Go for high performance and single-binary deployment
+- WebSocket protocol for firewall traversal
+- Supports Linux, Windows, and macOS
+- Docker containerization available
+
+## Open Issues and Feature Requests
+
+Based on community feedback, here are the key areas users are asking for improvements:
+
+### 1. Protocol Support Enhancement
+- **TCP/UDP Support** (#51, #31): Users want to tunnel non-HTTP traffic (e.g., RDP, SSH, WireGuard)
+- **WebSocket over WebSocket** (#48): Support for tunneling WebSocket traffic through the tunnel
+- **Audio/Video Streaming** (#56): Better support for streaming media
+
+### 2. Security and Authentication
+- **Token-based Authentication** (#50): Enhanced per-token security with individual passwords
+- **Client Certificates** (#41): Support for mTLS authentication
+- **Connection Limits** (#42): Ability to limit clients per token for better resource control
+
+### 3. Network and Connectivity
+- **IPv6 Support** (#74): Handle dynamic IPv6 addresses and DNS updates
+- **Reverse Connections** (#97): Support for reverse tunnel initiation
+- **Path-based Routing** (#68): Support for non-root URL paths when behind proxies
+
+### 4. Platform Support
+- **ARM Binaries** (#47): Support for ARM processors (Raspberry Pi, etc.)
+- **32-bit Linux** (#27): Legacy system support
+- **Android Client** (#45): Mobile platform support
+
+### 5. Operations and Monitoring
+- **HTTP Monitoring API** (#7): Metrics for tunnel counts, requests, errors
+- **Audit API** (#8): Track active connections and access patterns
+- **Version Reporting** (#18): Client version visibility on server
+
+### 6. Configuration and Usability
+- **Optional Tokens** (#46): Simplified setup for development environments
+- **Multi-tunnel Support** (#6): Single client managing multiple tunnels
+- **Request Limits** (#5): Configurable limits per tunnel
+- **Documentation** (#30): Clearer setup instructions
+
+## Product Strategy Considerations
+
+When prioritizing features, consider:
+
+1. **Security First**: Any changes must maintain or enhance security
+2. **Backward Compatibility**: Existing deployments must continue to work
+3. **Performance**: Solution must scale to thousands of concurrent connections
+4. **Simplicity**: Easy setup and configuration is a key differentiator
+5. **Reliability**: Production systems depend on stable tunnels
+
+## Your Role
+
+As the Product Manager, you should:
+
+1. **Analyze Feature Requests**: Evaluate the business value, technical complexity, and user impact
+2. **Create Product Roadmap**: Prioritize features into releases with clear milestones
+3. **Write Requirements**: Create detailed specifications for developers
+4. **Manage Trade-offs**: Balance features, performance, security, and maintainability
+5. **Community Engagement**: Respond to issues and gather user feedback
+6. **Competitive Analysis**: Compare with similar solutions (ngrok, frp, etc.)
+7. **Success Metrics**: Define KPIs for adoption, performance, and reliability
+
+## Key Questions to Consider
+
+- Which features would have the highest impact on user adoption?
+- How can we maintain simplicity while adding advanced features?
+- What security implications does each feature have?
+- Which features align with the core use cases vs. edge cases?
+- How do we balance community requests with project maintainability?
+
+## Next Steps
+
+Review the current issues, analyze user patterns, and create a prioritized roadmap that balances user needs with technical feasibility and project sustainability.

--- a/tunnel/client_config.go
+++ b/tunnel/client_config.go
@@ -1,0 +1,188 @@
+package tunnel
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ClientConfig holds the configuration for the WSTunnelClient
+type ClientConfig struct {
+	Token          string
+	Password       string
+	Tunnel         string
+	Server         string
+	Insecure       bool
+	Regexp         string
+	Timeout        int
+	PidFile        string
+	LogFile        string
+	StatusFile     string
+	Proxy          string
+	ClientPorts    string
+	CertFile       string
+	ReconnectDelay int
+	MaxRetries     int
+}
+
+// ParseClientConfig parses command line arguments into a ClientConfig
+func ParseClientConfig(args []string) (*ClientConfig, error) {
+	config := &ClientConfig{}
+
+	cliFlag := flag.NewFlagSet("client", flag.ContinueOnError)
+	cliFlag.SetOutput(io.Discard)
+	cliFlag.StringVar(&config.Token, "token", "",
+		"rendez-vous token identifying this server (format: token or token:password)")
+	cliFlag.StringVar(&config.Tunnel, "tunnel", "",
+		"websocket server ws[s]://user:pass@hostname:port to connect to")
+	cliFlag.StringVar(&config.Server, "server", "",
+		"http server http[s]://hostname:port to send received requests to")
+	cliFlag.BoolVar(&config.Insecure, "insecure", false,
+		"accept self-signed SSL certs from local HTTPS servers")
+	cliFlag.StringVar(&config.Regexp, "regexp", "",
+		"regexp for local HTTP(S) server to allow sending received requests to")
+	cliFlag.IntVar(&config.Timeout, "timeout", 30, "timeout on websocket in seconds")
+	cliFlag.StringVar(&config.PidFile, "pidfile", "", "path for pidfile")
+	cliFlag.StringVar(&config.LogFile, "logfile", "", "path for log file")
+	cliFlag.StringVar(&config.StatusFile, "statusfile", "", "path for status file")
+	cliFlag.StringVar(&config.Proxy, "proxy", "",
+		"use HTTPS proxy http://user:pass@hostname:port")
+	cliFlag.StringVar(&config.ClientPorts, "client-ports", "",
+		"comma separated list of client listening ports ex: -client-ports 8000..8100,8300..8400,8500,8505")
+	cliFlag.StringVar(&config.CertFile, "certfile", "", "path for trusted certificate in PEM-encoded format")
+	cliFlag.IntVar(&config.ReconnectDelay, "reconnect-delay", 5, "delay between reconnection attempts in seconds")
+	cliFlag.IntVar(&config.MaxRetries, "max-retries", 0, "maximum number of reconnection attempts (0 for unlimited)")
+
+	if err := cliFlag.Parse(args); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// NewWSTunnelClientFromConfig creates a new WSTunnelClient from a ClientConfig
+func NewWSTunnelClientFromConfig(config *ClientConfig) (*WSTunnelClient, error) {
+	client := &WSTunnelClient{
+		Token:       config.Token,
+		Password:    config.Password,
+		Server:      config.Server,
+		Insecure:    config.Insecure,
+		Cert:        config.CertFile,
+		Timeout:     time.Duration(config.Timeout) * time.Second,
+		Log:         makeLogger("WStuncli", config.LogFile, ""),
+		connManager: NewConnectionManager(time.Duration(config.ReconnectDelay)*time.Second, config.MaxRetries),
+	}
+
+	// Parse token:password format
+	if config.Token != "" {
+		parts := strings.SplitN(config.Token, ":", 2)
+		client.Token = strings.TrimSpace(parts[0])
+		if len(parts) == 2 {
+			client.Password = strings.TrimSpace(parts[1])
+		}
+	}
+
+	// Parse tunnel URL
+	if config.Tunnel != "" {
+		tunnelURL, err := url.Parse(config.Tunnel)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tunnel address: %q, %v", config.Tunnel, err)
+		}
+		if tunnelURL.Scheme != "ws" && tunnelURL.Scheme != "wss" {
+			return nil, fmt.Errorf("remote tunnel (-tunnel option) must begin with ws:// or wss://")
+		}
+		client.Tunnel = tunnelURL
+	} else {
+		return nil, fmt.Errorf("must specify tunnel server ws://hostname:port using -tunnel option")
+	}
+
+	// Parse regexp
+	if config.Regexp != "" {
+		var err error
+		client.Regexp, err = regexp.Compile(config.Regexp)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse -regexp: %v", err)
+		}
+	}
+
+	// Parse proxy
+	if config.Proxy != "" {
+		proxyURL, err := url.Parse(config.Proxy)
+		if err != nil || !strings.HasPrefix(proxyURL.Scheme, "http") {
+			if proxyURL, err = url.Parse("http://" + config.Proxy); err != nil {
+				return nil, fmt.Errorf("invalid proxy address: %q, %v", config.Proxy, err)
+			}
+		}
+		client.Proxy = proxyURL
+	}
+
+	// Parse client ports
+	if config.ClientPorts != "" {
+		ports, err := parseClientPorts(config.ClientPorts)
+		if err != nil {
+			return nil, err
+		}
+		client.ClientPorts = ports
+	}
+
+	// Create status file
+	if config.StatusFile != "" {
+		fd, err := os.Create(config.StatusFile)
+		if err != nil {
+			return nil, fmt.Errorf("can't create statusfile: %v", err)
+		}
+		client.StatusFd = fd
+	}
+
+	// Write PID file
+	if config.PidFile != "" {
+		if err := writePid(config.PidFile); err != nil {
+			return nil, fmt.Errorf("can't write pidfile: %v", err)
+		}
+	}
+
+	return client, nil
+}
+
+// parseClientPorts parses a comma-separated list of ports and port ranges
+func parseClientPorts(portsStr string) ([]int, error) {
+	portList := strings.Split(portsStr, ",")
+	clientPorts := []int{}
+
+	for _, v := range portList {
+		if strings.Contains(v, "..") {
+			k := strings.Split(v, "..")
+			bInt, err := strconv.Atoi(k[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid port assignment: %q in range: %q", k[0], v)
+			}
+
+			eInt, err := strconv.Atoi(k[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid port assignment: %q in range: %q", k[1], v)
+			}
+
+			if eInt < bInt {
+				return nil, fmt.Errorf("end port %d cannot be less than beginning port %d", eInt, bInt)
+			}
+
+			for n := bInt; n <= eInt; n++ {
+				clientPorts = append(clientPorts, n)
+			}
+		} else {
+			intPort, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert %q to integer", v)
+			}
+			clientPorts = append(clientPorts, intPort)
+		}
+	}
+
+	return clientPorts, nil
+}

--- a/tunnel/client_config_test.go
+++ b/tunnel/client_config_test.go
@@ -1,0 +1,733 @@
+// Copyright (c) 2024 RightScale, Inc. - see LICENSE
+
+package tunnel
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseClientConfig", func() {
+	Describe("Token parsing", func() {
+		It("should parse token without password", func() {
+			args := []string{"-token", "mytoken12345678901", "-tunnel", "ws://localhost:8080"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Token).To(Equal("mytoken12345678901"))
+			Expect(config.Password).To(Equal(""))
+		})
+
+		It("should parse token with password", func() {
+			args := []string{"-token", "mytoken12345678901:mypassword", "-tunnel", "ws://localhost:8080"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Token).To(Equal("mytoken12345678901:mypassword"))
+			Expect(config.Password).To(Equal(""))
+		})
+	})
+
+	Describe("URL flags validation", func() {
+		It("should parse valid tunnel URL", func() {
+			args := []string{"-tunnel", "ws://example.com:8080", "-token", "test"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Tunnel).To(Equal("ws://example.com:8080"))
+		})
+
+		It("should parse valid secure tunnel URL", func() {
+			args := []string{"-tunnel", "wss://user:pass@example.com:8443/path", "-token", "test"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Tunnel).To(Equal("wss://user:pass@example.com:8443/path"))
+		})
+
+		It("should parse valid server URL", func() {
+			args := []string{"-server", "http://localhost:3000", "-tunnel", "ws://example.com", "-token", "test"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Server).To(Equal("http://localhost:3000"))
+		})
+
+		It("should parse valid secure server URL", func() {
+			args := []string{"-server", "https://localhost:3443", "-tunnel", "ws://example.com", "-token", "test"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Server).To(Equal("https://localhost:3443"))
+		})
+	})
+
+	Describe("Boolean flags", func() {
+		It("should default insecure to false", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Insecure).To(BeFalse())
+		})
+
+		It("should parse insecure flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-insecure"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Insecure).To(BeTrue())
+		})
+	})
+
+	Describe("Numeric flags", func() {
+		It("should use default timeout", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Timeout).To(Equal(30))
+		})
+
+		It("should parse custom timeout", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-timeout", "60"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Timeout).To(Equal(60))
+		})
+
+		It("should use default reconnect-delay", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.ReconnectDelay).To(Equal(5))
+		})
+
+		It("should parse custom reconnect-delay", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-reconnect-delay", "10"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.ReconnectDelay).To(Equal(10))
+		})
+
+		It("should use default max-retries", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.MaxRetries).To(Equal(0))
+		})
+
+		It("should parse custom max-retries", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-max-retries", "3"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.MaxRetries).To(Equal(3))
+		})
+	})
+
+	Describe("String flags", func() {
+		It("should parse regexp flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-regexp", "^https?://[a-z]+\\.example\\.com"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Regexp).To(Equal("^https?://[a-z]+\\.example\\.com"))
+		})
+
+		It("should parse pidfile flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-pidfile", "/var/run/wstunnel.pid"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.PidFile).To(Equal("/var/run/wstunnel.pid"))
+		})
+
+		It("should parse logfile flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-logfile", "/var/log/wstunnel.log"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.LogFile).To(Equal("/var/log/wstunnel.log"))
+		})
+
+		It("should parse statusfile flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-statusfile", "/var/run/wstunnel.status"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.StatusFile).To(Equal("/var/run/wstunnel.status"))
+		})
+
+		It("should parse certfile flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-certfile", "/etc/ssl/certs/ca.pem"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.CertFile).To(Equal("/etc/ssl/certs/ca.pem"))
+		})
+
+		It("should parse proxy flag", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-proxy", "http://user:pass@proxy.example.com:8080"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Proxy).To(Equal("http://user:pass@proxy.example.com:8080"))
+		})
+	})
+
+	Describe("Client-ports parsing", func() {
+		It("should parse single port", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-client-ports", "8080"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.ClientPorts).To(Equal("8080"))
+		})
+
+		It("should parse multiple ports", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-client-ports", "8080,8081,8082"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.ClientPorts).To(Equal("8080,8081,8082"))
+		})
+
+		It("should parse port ranges", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-client-ports", "8000..8100"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.ClientPorts).To(Equal("8000..8100"))
+		})
+
+		It("should parse mixed ports and ranges", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-client-ports", "8000..8100,8300..8400,8500,8505"}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.ClientPorts).To(Equal("8000..8100,8300..8400,8500,8505"))
+		})
+	})
+
+	Describe("Error conditions", func() {
+		It("should handle empty arguments", func() {
+			args := []string{}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config).NotTo(BeNil())
+		})
+
+		It("should handle unknown flags", func() {
+			args := []string{"-unknown-flag", "value", "-token", "test", "-tunnel", "ws://localhost"}
+			_, err := ParseClientConfig(args)
+			// With ContinueOnError, unknown flags cause an error
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown"))
+		})
+
+		It("should handle missing flag values", func() {
+			args := []string{"-token"}
+			// This will cause flag.Parse to return an error
+			_, err := ParseClientConfig(args)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should handle invalid numeric values", func() {
+			args := []string{"-token", "test", "-tunnel", "ws://localhost", "-timeout", "invalid"}
+			_, err := ParseClientConfig(args)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("All flags combined", func() {
+		It("should parse all flags correctly", func() {
+			args := []string{
+				"-token", "mytoken12345678901:password123",
+				"-tunnel", "wss://user:pass@tunnel.example.com:8443/path",
+				"-server", "https://backend.local:3443",
+				"-insecure",
+				"-regexp", "^https?://.*\\.local",
+				"-timeout", "120",
+				"-pidfile", "/var/run/wstunnel.pid",
+				"-logfile", "/var/log/wstunnel.log",
+				"-statusfile", "/var/run/wstunnel.status",
+				"-proxy", "http://proxy.local:3128",
+				"-client-ports", "8000..8100,9000,9005",
+				"-certfile", "/etc/ssl/ca.pem",
+				"-reconnect-delay", "15",
+				"-max-retries", "5",
+			}
+			config, err := ParseClientConfig(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Token).To(Equal("mytoken12345678901:password123"))
+			Expect(config.Tunnel).To(Equal("wss://user:pass@tunnel.example.com:8443/path"))
+			Expect(config.Server).To(Equal("https://backend.local:3443"))
+			Expect(config.Insecure).To(BeTrue())
+			Expect(config.Regexp).To(Equal("^https?://.*\\.local"))
+			Expect(config.Timeout).To(Equal(120))
+			Expect(config.PidFile).To(Equal("/var/run/wstunnel.pid"))
+			Expect(config.LogFile).To(Equal("/var/log/wstunnel.log"))
+			Expect(config.StatusFile).To(Equal("/var/run/wstunnel.status"))
+			Expect(config.Proxy).To(Equal("http://proxy.local:3128"))
+			Expect(config.ClientPorts).To(Equal("8000..8100,9000,9005"))
+			Expect(config.CertFile).To(Equal("/etc/ssl/ca.pem"))
+			Expect(config.ReconnectDelay).To(Equal(15))
+			Expect(config.MaxRetries).To(Equal(5))
+		})
+	})
+})
+
+// TestParseClientConfig provides additional unit tests using Go's standard testing
+func TestParseClientConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		checkConfig func(*testing.T, *ClientConfig)
+	}{
+		{
+			name: "minimal valid config",
+			args: []string{"-token", "test123456789012", "-tunnel", "ws://localhost:8080"},
+			checkConfig: func(t *testing.T, cfg *ClientConfig) {
+				if cfg.Token != "test123456789012" {
+					t.Errorf("Expected token 'test123456789012', got %q", cfg.Token)
+				}
+				if cfg.Tunnel != "ws://localhost:8080" {
+					t.Errorf("Expected tunnel 'ws://localhost:8080', got %q", cfg.Tunnel)
+				}
+			},
+		},
+		{
+			name: "token with special characters",
+			args: []string{"-token", "token!@#$%^&*()_+-=:pass!@#$", "-tunnel", "ws://localhost"},
+			checkConfig: func(t *testing.T, cfg *ClientConfig) {
+				if cfg.Token != "token!@#$%^&*()_+-=:pass!@#$" {
+					t.Errorf("Expected token with special chars, got %q", cfg.Token)
+				}
+			},
+		},
+		{
+			name: "empty token allowed",
+			args: []string{"-token", "", "-tunnel", "ws://localhost"},
+			checkConfig: func(t *testing.T, cfg *ClientConfig) {
+				if cfg.Token != "" {
+					t.Errorf("Expected empty token, got %q", cfg.Token)
+				}
+			},
+		},
+		{
+			name:    "invalid timeout value",
+			args:    []string{"-token", "test", "-tunnel", "ws://localhost", "-timeout", "not-a-number"},
+			wantErr: true,
+		},
+		{
+			name:    "negative timeout value",
+			args:    []string{"-token", "test", "-tunnel", "ws://localhost", "-timeout", "-5"},
+			wantErr: false, // Flag package allows negative values
+			checkConfig: func(t *testing.T, cfg *ClientConfig) {
+				if cfg.Timeout != -5 {
+					t.Errorf("Expected timeout -5, got %d", cfg.Timeout)
+				}
+			},
+		},
+		{
+			name: "boolean flag variations",
+			args: []string{"-token", "test", "-tunnel", "ws://localhost", "-insecure=true"},
+			checkConfig: func(t *testing.T, cfg *ClientConfig) {
+				if !cfg.Insecure {
+					t.Error("Expected insecure to be true")
+				}
+			},
+		},
+		{
+			name: "flag with equals sign",
+			args: []string{"-token=test123456789012", "-tunnel=ws://localhost:8080"},
+			checkConfig: func(t *testing.T, cfg *ClientConfig) {
+				if cfg.Token != "test123456789012" {
+					t.Errorf("Expected token 'test123456789012', got %q", cfg.Token)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := ParseClientConfig(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseClientConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.checkConfig != nil {
+				tt.checkConfig(t, config)
+			}
+		})
+	}
+}
+
+var _ = Describe("Client Config Token:Password Parsing", func() {
+	Describe("NewWSTunnelClientFromConfig token:password parsing", func() {
+		It("should parse token without password", func() {
+			config := &ClientConfig{
+				Token:  "mytoken12345678901",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal(""))
+		})
+
+		It("should parse token with password", func() {
+			config := &ClientConfig{
+				Token:  "mytoken12345678901:mypassword",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal("mypassword"))
+		})
+
+		It("should handle token with multiple colons", func() {
+			config := &ClientConfig{
+				Token:  "mytoken12345678901:password:with:colons",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal("password:with:colons"))
+		})
+
+		It("should handle empty token before colon", func() {
+			config := &ClientConfig{
+				Token:  ":password",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal(""))
+			Expect(client.Password).To(Equal("password"))
+		})
+
+		It("should handle empty password after colon", func() {
+			config := &ClientConfig{
+				Token:  "mytoken12345678901:",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal(""))
+		})
+
+		It("should handle completely empty token", func() {
+			config := &ClientConfig{
+				Token:  "",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal(""))
+			Expect(client.Password).To(Equal(""))
+		})
+
+		It("should handle token with special characters", func() {
+			config := &ClientConfig{
+				Token:  "token!@#$%^&*()_+-=:pass!@#$%^&*()_+-=",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("token!@#$%^&*()_+-="))
+			Expect(client.Password).To(Equal("pass!@#$%^&*()_+-="))
+		})
+
+		It("should handle token with URL-unsafe characters", func() {
+			config := &ClientConfig{
+				Token:  "token<>[]{}|\\:pass<>[]{}|\\",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("token<>[]{}|\\"))
+			Expect(client.Password).To(Equal("pass<>[]{}|\\"))
+		})
+
+		It("should handle very long token", func() {
+			longToken := strings.Repeat("a", 1000)
+			config := &ClientConfig{
+				Token:  longToken + ":password",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal(longToken))
+			Expect(client.Password).To(Equal("password"))
+		})
+
+		It("should handle very long password", func() {
+			longPassword := strings.Repeat("b", 1000)
+			config := &ClientConfig{
+				Token:  "mytoken12345678901:" + longPassword,
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal(longPassword))
+		})
+
+		It("should handle very long token and password", func() {
+			longToken := strings.Repeat("a", 1000)
+			longPassword := strings.Repeat("b", 1000)
+			config := &ClientConfig{
+				Token:  longToken + ":" + longPassword,
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal(longToken))
+			Expect(client.Password).To(Equal(longPassword))
+		})
+
+		It("should handle only colon as token", func() {
+			config := &ClientConfig{
+				Token:  ":",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal(""))
+			Expect(client.Password).To(Equal(""))
+		})
+
+		It("should handle multiple consecutive colons", func() {
+			config := &ClientConfig{
+				Token:  "token:::password",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("token"))
+			Expect(client.Password).To(Equal("::password"))
+		})
+
+		It("should handle newlines in token and password", func() {
+			config := &ClientConfig{
+				Token:  "token\nwith\nnewline:pass\nwith\nnewline",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("token\nwith\nnewline"))
+			Expect(client.Password).To(Equal("pass\nwith\nnewline"))
+		})
+
+		It("should handle tabs and spaces", func() {
+			config := &ClientConfig{
+				Token:  "token with spaces:pass\twith\ttabs",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("token with spaces"))
+			Expect(client.Password).To(Equal("pass\twith\ttabs"))
+		})
+
+		It("should handle unicode characters", func() {
+			config := &ClientConfig{
+				Token:  "token🔒unicode:pass🔑word",
+				Tunnel: "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("token🔒unicode"))
+			Expect(client.Password).To(Equal("pass🔑word"))
+		})
+
+		It("should preserve explicit password parameter when no colon in token", func() {
+			config := &ClientConfig{
+				Token:    "mytoken12345678901",
+				Password: "explicitpassword",
+				Tunnel:   "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal("explicitpassword"))
+		})
+
+		It("should override explicit password parameter when colon in token", func() {
+			config := &ClientConfig{
+				Token:    "mytoken12345678901:colonpassword",
+				Password: "explicitpassword",
+				Tunnel:   "ws://localhost:8080",
+			}
+			client, err := NewWSTunnelClientFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Token).To(Equal("mytoken12345678901"))
+			Expect(client.Password).To(Equal("colonpassword"))
+		})
+	})
+})
+
+// TestTokenPasswordParsingUnit provides additional unit tests using Go's standard testing
+func TestTokenPasswordParsingUnit(t *testing.T) {
+	tests := []struct {
+		name             string
+		token            string
+		expectedToken    string
+		expectedPassword string
+	}{
+		{
+			name:             "token without password",
+			token:            "simpletoken12345678",
+			expectedToken:    "simpletoken12345678",
+			expectedPassword: "",
+		},
+		{
+			name:             "token with password",
+			token:            "token12345678901:password123",
+			expectedToken:    "token12345678901",
+			expectedPassword: "password123",
+		},
+		{
+			name:             "token with password containing colons",
+			token:            "token12345678901:pass:word:123",
+			expectedToken:    "token12345678901",
+			expectedPassword: "pass:word:123",
+		},
+		{
+			name:             "empty token with password",
+			token:            ":justpassword",
+			expectedToken:    "",
+			expectedPassword: "justpassword",
+		},
+		{
+			name:             "token with empty password",
+			token:            "token12345678901:",
+			expectedToken:    "token12345678901",
+			expectedPassword: "",
+		},
+		{
+			name:             "just a colon",
+			token:            ":",
+			expectedToken:    "",
+			expectedPassword: "",
+		},
+		{
+			name:             "empty string",
+			token:            "",
+			expectedToken:    "",
+			expectedPassword: "",
+		},
+		{
+			name:             "multiple consecutive colons at start",
+			token:            ":::password",
+			expectedToken:    "",
+			expectedPassword: "::password",
+		},
+		{
+			name:             "multiple consecutive colons at end",
+			token:            "token:::",
+			expectedToken:    "token",
+			expectedPassword: "::",
+		},
+		{
+			name:             "special characters in token",
+			token:            "tok!@#$%^&*()_+-=en:pass!@#$%^&*()_+-=word",
+			expectedToken:    "tok!@#$%^&*()_+-=en",
+			expectedPassword: "pass!@#$%^&*()_+-=word",
+		},
+		{
+			name:             "URL-like password",
+			token:            "mytoken:https://user:pass@example.com",
+			expectedToken:    "mytoken",
+			expectedPassword: "https://user:pass@example.com",
+		},
+		{
+			name:             "base64 encoded values",
+			token:            "dG9rZW4=:cGFzc3dvcmQ=",
+			expectedToken:    "dG9rZW4=",
+			expectedPassword: "cGFzc3dvcmQ=",
+		},
+		{
+			name:             "very long token (1000 chars)",
+			token:            strings.Repeat("a", 1000) + ":password",
+			expectedToken:    strings.Repeat("a", 1000),
+			expectedPassword: "password",
+		},
+		{
+			name:             "very long password (1000 chars)",
+			token:            "token:" + strings.Repeat("b", 1000),
+			expectedToken:    "token",
+			expectedPassword: strings.Repeat("b", 1000),
+		},
+		{
+			name:             "both very long (500 chars each)",
+			token:            strings.Repeat("x", 500) + ":" + strings.Repeat("y", 500),
+			expectedToken:    strings.Repeat("x", 500),
+			expectedPassword: strings.Repeat("y", 500),
+		},
+		{
+			name:             "whitespace in token and password",
+			token:            "token with spaces:password with spaces",
+			expectedToken:    "token with spaces",
+			expectedPassword: "password with spaces",
+		},
+		{
+			name:             "tabs and newlines",
+			token:            "token\twith\ttabs:pass\nwith\nnewlines",
+			expectedToken:    "token\twith\ttabs",
+			expectedPassword: "pass\nwith\nnewlines",
+		},
+		{
+			name:             "unicode characters",
+			token:            "token🔐:password🔑",
+			expectedToken:    "token🔐",
+			expectedPassword: "password🔑",
+		},
+		{
+			name:             "percent encoded characters",
+			token:            "token%20with%20encoded:pass%3Aword",
+			expectedToken:    "token%20with%20encoded",
+			expectedPassword: "pass%3Aword",
+		},
+		{
+			name:             "JSON-like password",
+			token:            `token:{"key":"value","nested":{"a":1}}`,
+			expectedToken:    "token",
+			expectedPassword: `{"key":"value","nested":{"a":1}}`,
+		},
+		{
+			name:             "SQL injection attempt in password",
+			token:            "token:'; DROP TABLE users; --",
+			expectedToken:    "token",
+			expectedPassword: "'; DROP TABLE users; --",
+		},
+		{
+			name:             "path traversal in password",
+			token:            "token:../../../etc/passwd",
+			expectedToken:    "token",
+			expectedPassword: "../../../etc/passwd",
+		},
+		{
+			name:             "null bytes",
+			token:            "token\x00with\x00null:pass\x00word",
+			expectedToken:    "token\x00with\x00null",
+			expectedPassword: "pass\x00word",
+		},
+		{
+			name:             "binary data simulation",
+			token:            "token:\x01\x02\x03\x04\x05",
+			expectedToken:    "token",
+			expectedPassword: "\x01\x02\x03\x04\x05",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the parsing logic from client_config.go
+			var token, password string
+			if tt.token != "" {
+				parts := strings.SplitN(tt.token, ":", 2)
+				token = parts[0]
+				if len(parts) == 2 {
+					password = parts[1]
+				}
+			}
+
+			if token != tt.expectedToken {
+				t.Errorf("Expected token %q, got %q", tt.expectedToken, token)
+			}
+			if password != tt.expectedPassword {
+				t.Errorf("Expected password %q, got %q", tt.expectedPassword, password)
+			}
+		})
+	}
+}

--- a/tunnel/client_impl.go
+++ b/tunnel/client_impl.go
@@ -1,0 +1,114 @@
+package tunnel
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ClientImpl provides the implementation of the WSTunnelClient
+type ClientImpl struct {
+	client         *WSTunnelClient
+	statusWriterWg sync.WaitGroup
+}
+
+// NewClientImpl creates a new ClientImpl
+func NewClientImpl(client *WSTunnelClient) *ClientImpl {
+	return &ClientImpl{
+		client: client,
+	}
+}
+
+// Start starts the client
+func (ci *ClientImpl) Start() error {
+	ci.client.Log.Info("Starting wstunnel client")
+
+	// validate -server
+	if ci.client.InternalServer != nil {
+		ci.client.Server = ""
+	} else if ci.client.Server != "" {
+		if !strings.HasPrefix(ci.client.Server, "http://") && !strings.HasPrefix(ci.client.Server, "https://") {
+			return fmt.Errorf("local server (-server option) must begin with http:// or https://")
+		}
+		ci.client.Server = strings.TrimSuffix(ci.client.Server, "/")
+	}
+
+	// Create connection handler
+	handler := NewConnectionHandler(ci.client)
+
+	// Start connection with retry logic
+	err := handler.Reconnect()
+	if err != nil {
+		return fmt.Errorf("failed to establish connection: %v", err)
+	}
+
+	// Start status writer if configured
+	if ci.client.StatusFd != nil {
+		ci.statusWriterWg.Add(1)
+		go ci.startStatusWriter(handler)
+	}
+
+	return nil
+}
+
+// Stop stops the client
+func (ci *ClientImpl) Stop() {
+	close(ci.client.exitChan)
+
+	// Wait for status writer to exit before closing StatusFd
+	ci.statusWriterWg.Wait()
+
+	if ci.client.conn != nil {
+		if err := ci.client.conn.ws.Close(); err != nil {
+			ci.client.Log.Error("Failed to close websocket", "err", err)
+		}
+	}
+	if ci.client.StatusFd != nil {
+		if err := ci.client.StatusFd.Close(); err != nil {
+			ci.client.Log.Error("Failed to close status file", "err", err)
+		}
+	}
+}
+
+// startStatusWriter writes periodic status updates
+func (ci *ClientImpl) startStatusWriter(handler *ConnectionHandler) {
+	defer ci.statusWriterWg.Done()
+
+	for {
+		select {
+		case <-ci.client.exitChan:
+			return
+		case <-time.After(time.Second):
+			stats := handler.GetStats()
+			if _, err := fmt.Fprintf(ci.client.StatusFd, "Connected: %v, Total Connections: %d, Failed Connections: %d, Last Error: %v\n",
+				handler.IsConnected(), stats.TotalConnections, stats.FailedConnections, stats.LastError); err != nil {
+				ci.client.Log.Error("Failed to write to status file", "err", err)
+			}
+		}
+	}
+}
+
+// GetStats returns the current client statistics
+func (ci *ClientImpl) GetStats() ClientStats {
+	if ci == nil || ci.client == nil || ci.client.connManager == nil {
+		return ClientStats{} // Return zero value
+	}
+	return ci.client.connManager.GetStats()
+}
+
+// IsConnected returns true if the client is connected
+func (ci *ClientImpl) IsConnected() bool {
+	if ci == nil || ci.client == nil {
+		return false
+	}
+	return ci.client.IsConnected() && ci.client.conn != nil && ci.client.conn.ws != nil
+}
+
+// GetLastError returns the last error encountered
+func (ci *ClientImpl) GetLastError() error {
+	if ci == nil || ci.client == nil || ci.client.connManager == nil {
+		return nil
+	}
+	return ci.client.connManager.GetLastError()
+}

--- a/tunnel/client_stats.go
+++ b/tunnel/client_stats.go
@@ -1,0 +1,80 @@
+package tunnel
+
+import (
+	"sync"
+	"time"
+)
+
+// ClientStats tracks connection statistics
+type ClientStats struct {
+	TotalConnections   int64
+	FailedConnections  int64
+	SuccessfulRequests int64
+	FailedRequests     int64
+	LastError          error
+	LastErrorTime      time.Time
+	LastSuccessTime    time.Time
+	TotalBytesSent     int64
+	TotalBytesReceived int64
+	mu                 sync.RWMutex
+}
+
+// NewClientStats creates a new ClientStats instance
+func NewClientStats() *ClientStats {
+	return &ClientStats{}
+}
+
+// RecordConnection records a new connection attempt
+func (s *ClientStats) RecordConnection(success bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.TotalConnections++
+	if !success {
+		s.FailedConnections++
+	}
+}
+
+// RecordRequest records a new request attempt
+func (s *ClientStats) RecordRequest(success bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if success {
+		s.SuccessfulRequests++
+		s.LastSuccessTime = time.Now()
+	} else {
+		s.FailedRequests++
+	}
+}
+
+// RecordError records a new error
+func (s *ClientStats) RecordError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.LastError = err
+	s.LastErrorTime = time.Now()
+}
+
+// RecordBytes records bytes sent/received
+func (s *ClientStats) RecordBytes(sent, received int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.TotalBytesSent += sent
+	s.TotalBytesReceived += received
+}
+
+// GetStats returns a copy of the current statistics
+func (s *ClientStats) GetStats() ClientStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return ClientStats{
+		TotalConnections:   s.TotalConnections,
+		FailedConnections:  s.FailedConnections,
+		SuccessfulRequests: s.SuccessfulRequests,
+		FailedRequests:     s.FailedRequests,
+		LastError:          s.LastError,
+		LastErrorTime:      s.LastErrorTime,
+		LastSuccessTime:    s.LastSuccessTime,
+		TotalBytesSent:     s.TotalBytesSent,
+		TotalBytesReceived: s.TotalBytesReceived,
+	}
+}

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -1,0 +1,158 @@
+package tunnel
+
+import (
+	"sync"
+	"time"
+)
+
+// ConnectionState represents the current state of a connection
+type ConnectionState int
+
+const (
+	// ConnectionStateDisconnected indicates no active connection
+	ConnectionStateDisconnected ConnectionState = iota
+	// ConnectionStateConnecting indicates a connection attempt is in progress
+	ConnectionStateConnecting
+	// ConnectionStateConnected indicates an active connection
+	ConnectionStateConnected
+	// ConnectionStateFailed indicates a failed connection
+	ConnectionStateFailed
+)
+
+// ConnectionManager handles connection lifecycle and retry logic
+type ConnectionManager struct {
+	ReconnectDelay time.Duration
+	MaxRetries     int
+	retryCount     int
+	lastError      error
+	errorChan      chan error
+	stats          *ClientStats
+	state          ConnectionState
+	mu             sync.RWMutex
+}
+
+// NewConnectionManager creates a new ConnectionManager instance
+func NewConnectionManager(reconnectDelay time.Duration, maxRetries int) *ConnectionManager {
+	return &ConnectionManager{
+		ReconnectDelay: reconnectDelay,
+		MaxRetries:     maxRetries,
+		errorChan:      make(chan error, 100),
+		stats:          NewClientStats(),
+		state:          ConnectionStateDisconnected,
+	}
+}
+
+// RecordError records a connection error and determines if retry is possible
+func (cm *ConnectionManager) RecordError(err error) bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.lastError = err
+	cm.stats.RecordError(err)
+	cm.stats.RecordConnection(false)
+	cm.state = ConnectionStateFailed
+
+	// Check if we should retry
+	if cm.MaxRetries > 0 && cm.retryCount >= cm.MaxRetries {
+		return false
+	}
+
+	cm.retryCount++
+	return true
+}
+
+// RecordSuccess records a successful connection
+func (cm *ConnectionManager) RecordSuccess() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.retryCount = 0
+	cm.lastError = nil
+	cm.stats.RecordConnection(true)
+	cm.state = ConnectionStateConnected
+}
+
+// SetState sets the current connection state
+func (cm *ConnectionManager) SetState(state ConnectionState) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.state = state
+}
+
+// GetState returns the current connection state
+func (cm *ConnectionManager) GetState() ConnectionState {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.state
+}
+
+// GetRetryDelay returns the delay before the next retry attempt
+func (cm *ConnectionManager) GetRetryDelay() time.Duration {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	if cm.retryCount == 0 {
+		return 0
+	}
+
+	// Exponential backoff with jitter
+	delay := cm.ReconnectDelay * time.Duration(cm.retryCount)
+	jitter := time.Duration(float64(delay) * 0.1) // 10% jitter
+	return delay + jitter
+}
+
+// GetStats returns the current connection statistics
+func (cm *ConnectionManager) GetStats() ClientStats {
+	return cm.stats.GetStats()
+}
+
+// GetLastError returns the last recorded error
+func (cm *ConnectionManager) GetLastError() error {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.lastError
+}
+
+// Reset resets the connection manager state
+func (cm *ConnectionManager) Reset() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.retryCount = 0
+	cm.lastError = nil
+	cm.state = ConnectionStateDisconnected
+}
+
+// IsConnected returns true if the connection is in a connected state
+func (cm *ConnectionManager) IsConnected() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.state == ConnectionStateConnected
+}
+
+// ShouldRetry checks if retry is possible without recording an error
+func (cm *ConnectionManager) ShouldRetry() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	// Check if we should retry
+	if cm.MaxRetries > 0 && cm.retryCount >= cm.MaxRetries {
+		return false
+	}
+
+	return true
+}
+
+// IsConnecting returns true if a connection attempt is in progress
+func (cm *ConnectionManager) IsConnecting() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.state == ConnectionStateConnecting
+}
+
+// IsFailed returns true if the connection is in a failed state
+func (cm *ConnectionManager) IsFailed() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.state == ConnectionStateFailed
+}

--- a/tunnel/connection_handler.go
+++ b/tunnel/connection_handler.go
@@ -1,0 +1,174 @@
+package tunnel
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+// ConnectionHandler handles the websocket connection lifecycle
+type ConnectionHandler struct {
+	client *WSTunnelClient
+	conn   *WSConnection
+	log    log15.Logger
+}
+
+// NewConnectionHandler creates a new ConnectionHandler
+func NewConnectionHandler(client *WSTunnelClient) *ConnectionHandler {
+	return &ConnectionHandler{
+		client: client,
+		log:    client.Log.New("component", "connection_handler"),
+	}
+}
+
+// Connect establishes a new websocket connection
+func (ch *ConnectionHandler) Connect() error {
+	ch.client.connManager.SetState(ConnectionStateConnecting)
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: ch.client.Timeout,
+		ReadBufferSize:   1024,
+		WriteBufferSize:  1024,
+	}
+
+	// Set up proxy if configured
+	if ch.client.Proxy != nil {
+		dialer.Proxy = http.ProxyURL(ch.client.Proxy)
+	}
+
+	// Set up TLS if using secure connection
+	if ch.client.Tunnel.Scheme == "wss" {
+		dialer.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: ch.client.Insecure,
+			MinVersion:         tls.VersionTLS12, // Enforce minimum TLS 1.2
+		}
+		if ch.client.Cert != "" {
+			// Load CA certificate for server verification
+			caCert, err := os.ReadFile(ch.client.Cert)
+			if err != nil {
+				return fmt.Errorf("failed to read certificate file: %v", err)
+			}
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				return fmt.Errorf("failed to parse certificate")
+			}
+			dialer.TLSClientConfig.RootCAs = caCertPool
+		}
+	}
+
+	// Set up local port binding if configured
+	if len(ch.client.ClientPorts) > 0 {
+		dialer.NetDial = func(network, addr string) (net.Conn, error) {
+			return ch.client.wsDialerLocalPort(network, addr, ch.client.ClientPorts)
+		}
+	}
+
+	// Add authentication headers if configured
+	header := http.Header{}
+	if ch.client.Token != "" {
+		// Set token in Origin header (server expects it there)
+		header.Set("Origin", ch.client.Token)
+
+		// If password is provided, use HTTP Basic Auth
+		if ch.client.Password != "" {
+			auth := ch.client.Token + ":" + ch.client.Password
+			encodedAuth := base64.StdEncoding.EncodeToString([]byte(auth))
+			header.Set("Authorization", "Basic "+encodedAuth)
+		}
+	}
+
+	// Connect to the websocket server
+	ws, _, err := dialer.Dial(ch.client.Tunnel.String(), header)
+	if err != nil {
+		ch.client.connManager.RecordError(err)
+		return fmt.Errorf("failed to connect to websocket server: %v", err)
+	}
+
+	// Create new connection
+	ch.conn = &WSConnection{
+		Log: ch.log.New("ws", fmt.Sprintf("%p", ws)),
+		ws:  ws,
+		tun: ch.client,
+	}
+
+	ch.client.conn = ch.conn
+	ch.client.connManager.RecordSuccess()
+	ch.client.setConnected(true)
+
+	// Start connection handlers
+	go ch.conn.handleRequests()
+	go ch.conn.pinger()
+
+	return nil
+}
+
+// Disconnect closes the current websocket connection
+func (ch *ConnectionHandler) Disconnect() error {
+	if ch.conn != nil && ch.conn.ws != nil {
+		ch.log.Info("Closing websocket connection")
+		err := ch.conn.ws.Close()
+		ch.conn = nil
+		ch.client.conn = nil
+		ch.client.setConnected(false)
+		return err
+	}
+	return nil
+}
+
+// Reconnect attempts to establish a new connection with retry logic
+func (ch *ConnectionHandler) Reconnect() error {
+	// Disconnect existing connection if any
+	if err := ch.Disconnect(); err != nil {
+		ch.log.Warn("Error disconnecting existing connection", "err", err)
+	}
+
+	// Try to connect with retry logic
+	for {
+		err := ch.Connect()
+		if err == nil {
+			return nil
+		}
+
+		ch.log.Error("Connection failed", "err", err)
+
+		// Check if we should retry (error was already recorded in Connect)
+		if !ch.client.connManager.ShouldRetry() {
+			return fmt.Errorf("max retries exceeded: %v", err)
+		}
+
+		// Calculate delay before next attempt
+		delay := ch.client.connManager.GetRetryDelay()
+		ch.log.Info("Retrying connection", "delay", delay)
+
+		// Wait for delay or exit signal
+		select {
+		case <-time.After(delay):
+			continue
+		case <-ch.client.exitChan:
+			return fmt.Errorf("connection attempt cancelled")
+		}
+	}
+}
+
+// IsConnected returns true if there is an active connection
+func (ch *ConnectionHandler) IsConnected() bool {
+	return ch.conn != nil && ch.conn.ws != nil && ch.client.IsConnected()
+}
+
+// GetStats returns the current connection statistics
+func (ch *ConnectionHandler) GetStats() ClientStats {
+	return ch.client.connManager.GetStats()
+}
+
+// GetLastError returns the last connection error
+func (ch *ConnectionHandler) GetLastError() error {
+	return ch.client.connManager.GetLastError()
+}

--- a/tunnel/helpers.go
+++ b/tunnel/helpers.go
@@ -19,24 +19,24 @@ var VV string
 // SetVV Used for versioning build
 func SetVV(vv string) { VV = vv }
 
-func writePid(file string) {
+func writePid(file string) error {
 	if file != "" {
 		_ = os.Remove(file)
 		pid := os.Getpid()
 		f, err := os.Create(file)
 		if err != nil {
-			log15.Crit("Can't create pidfile", "file", file, "err", err.Error())
-			os.Exit(1)
+			return fmt.Errorf("can't create pidfile %s: %v", file, err)
 		}
 		_, err = f.WriteString(strconv.Itoa(pid) + "\n")
 		if err != nil {
-			log15.Crit("Can't write to pidfile", "file", file, "err", err.Error())
-			os.Exit(1)
+			_ = f.Close()
+			return fmt.Errorf("can't write to pidfile %s: %v", file, err)
 		}
 		if err := f.Close(); err != nil {
-			log15.Error("Failed to close pidfile", "err", err)
+			return fmt.Errorf("failed to close pidfile: %v", err)
 		}
 	}
+	return nil
 }
 
 const simpleTimeFormat = "2006-01-02 15:04:05"

--- a/tunnel/misc_test.go
+++ b/tunnel/misc_test.go
@@ -57,7 +57,7 @@ waitLoop:
 			// If we time out, just continue - the test will fail if needed
 			break waitLoop
 		case <-ticker.C:
-			if wstuncli.Connected {
+			if wstuncli.IsConnected() {
 				break waitLoop
 			}
 		}
@@ -88,112 +88,112 @@ func TestReconnectWebsocket(t *testing.T) {
 	// Skip this test for now during the migration from Ginkgo to standard Go tests
 	// This test has issues with WebSocket handshake that need further investigation
 	t.Skip("Skipping test during migration from Ginkgo to standard Go tests")
-	
+
 	// Original test implementation left in place but commented out for reference
 	/*
-	// Setup test environment
-	wstunToken := "test567890123456-" + strconv.Itoa(rand.Int()%1000000)
+			// Setup test environment
+			wstunToken := "test567890123456-" + strconv.Itoa(rand.Int()%1000000)
 
-	// Setup handler with different responses for each call
-	requestCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/hello" {
-			w.Header().Set("Content-Type", "text/world")
-			w.WriteHeader(200)
-			if requestCount == 0 {
-				_, _ = w.Write([]byte("WORLD"))
-				requestCount++
+			// Setup handler with different responses for each call
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/hello" {
+					w.Header().Set("Content-Type", "text/world")
+					w.WriteHeader(200)
+					if requestCount == 0 {
+						_, _ = w.Write([]byte("WORLD"))
+						requestCount++
+					} else {
+						_, _ = w.Write([]byte("AGAIN"))
+					}
+				}
+			}))
+			defer server.Close()
+
+			listener, _ := net.Listen("tcp", "127.0.0.1:0")
+			wstunsrv := NewWSTunnelServer([]string{
+				"-wstimeout", "5", // Reduce timeout for testing
+			})
+			wstunsrv.Start(listener)
+			defer wstunsrv.Stop()
+
+			wstuncli := NewWSTunnelClient([]string{
+				"-token", wstunToken,
+				"-tunnel", "ws://" + listener.Addr().String(),
+				"-server", server.URL,
+				"-timeout", "3",
+			})
+			if err := wstuncli.Start(); err != nil {
+				t.Fatalf("Error starting client: %v", err)
+			}
+			defer wstuncli.Stop()
+
+			wstunURL := "http://" + listener.Addr().String()
+
+			// Wait for client to connect with timeout
+			timeout := time.After(5 * time.Second)
+			ticker := time.NewTicker(10 * time.Millisecond)
+			defer ticker.Stop()
+
+		waitLoop:
+			for {
+				select {
+				case <-timeout:
+					// If we time out, just continue - the test will fail if needed
+					break waitLoop
+				case <-ticker.C:
+					if wstuncli.IsConnected() {
+						break waitLoop
+					}
+				}
+			}
+
+			// First request
+			resp, err := http.Get(wstunURL + "/_token/" + wstunToken + "/hello")
+			if err != nil {
+				t.Fatalf("Error making request: %v", err)
+			}
+			respBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Error reading response: %v", err)
+			}
+			if string(respBody) != "WORLD" {
+				t.Errorf("Expected response body to be WORLD, got %s", string(respBody))
+			}
+			if resp.Header.Get("Content-Type") != "text/world" {
+				t.Errorf("Expected Content-Type to be text/world, got %s", resp.Header.Get("Content-Type"))
+			}
+			if resp.StatusCode != 200 {
+				t.Errorf("Expected status code to be 200, got %d", resp.StatusCode)
+			}
+
+			// Break the tunnel - add a safety check to prevent the nil pointer dereference
+			if wstuncli != nil && wstuncli.conn != nil && wstuncli.conn.ws != nil {
+				if err := wstuncli.conn.ws.Close(); err != nil {
+					t.Logf("Failed to close websocket: %v", err)
+				}
 			} else {
-				_, _ = w.Write([]byte("AGAIN"))
+				t.Logf("Cannot close websocket: connection not fully established")
 			}
-		}
-	}))
-	defer server.Close()
+			time.Sleep(20 * time.Millisecond)
 
-	listener, _ := net.Listen("tcp", "127.0.0.1:0")
-	wstunsrv := NewWSTunnelServer([]string{
-		"-wstimeout", "5", // Reduce timeout for testing
-	})
-	wstunsrv.Start(listener)
-	defer wstunsrv.Stop()
-
-	wstuncli := NewWSTunnelClient([]string{
-		"-token", wstunToken,
-		"-tunnel", "ws://" + listener.Addr().String(),
-		"-server", server.URL,
-		"-timeout", "3",
-	})
-	if err := wstuncli.Start(); err != nil {
-		t.Fatalf("Error starting client: %v", err)
-	}
-	defer wstuncli.Stop()
-
-	wstunURL := "http://" + listener.Addr().String()
-
-	// Wait for client to connect with timeout
-	timeout := time.After(5 * time.Second)
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-waitLoop:
-	for {
-		select {
-		case <-timeout:
-			// If we time out, just continue - the test will fail if needed
-			break waitLoop
-		case <-ticker.C:
-			if wstuncli.Connected {
-				break waitLoop
+			// Second request (should reconnect)
+			resp, err = http.Get(wstunURL + "/_token/" + wstunToken + "/hello")
+			if err != nil {
+				t.Fatalf("Error making request: %v", err)
 			}
-		}
-	}
-
-	// First request
-	resp, err := http.Get(wstunURL + "/_token/" + wstunToken + "/hello")
-	if err != nil {
-		t.Fatalf("Error making request: %v", err)
-	}
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Error reading response: %v", err)
-	}
-	if string(respBody) != "WORLD" {
-		t.Errorf("Expected response body to be WORLD, got %s", string(respBody))
-	}
-	if resp.Header.Get("Content-Type") != "text/world" {
-		t.Errorf("Expected Content-Type to be text/world, got %s", resp.Header.Get("Content-Type"))
-	}
-	if resp.StatusCode != 200 {
-		t.Errorf("Expected status code to be 200, got %d", resp.StatusCode)
-	}
-
-	// Break the tunnel - add a safety check to prevent the nil pointer dereference
-	if wstuncli != nil && wstuncli.conn != nil && wstuncli.conn.ws != nil {
-		if err := wstuncli.conn.ws.Close(); err != nil {
-			t.Logf("Failed to close websocket: %v", err)
-		}
-	} else {
-		t.Logf("Cannot close websocket: connection not fully established")
-	}
-	time.Sleep(20 * time.Millisecond)
-
-	// Second request (should reconnect)
-	resp, err = http.Get(wstunURL + "/_token/" + wstunToken + "/hello")
-	if err != nil {
-		t.Fatalf("Error making request: %v", err)
-	}
-	respBody, err = io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Error reading response: %v", err)
-	}
-	if string(respBody) != "AGAIN" {
-		t.Errorf("Expected response body to be AGAIN, got %s", string(respBody))
-	}
-	if resp.Header.Get("Content-Type") != "text/world" {
-		t.Errorf("Expected Content-Type to be text/world, got %s", resp.Header.Get("Content-Type"))
-	}
-	if resp.StatusCode != 200 {
-		t.Errorf("Expected status code to be 200, got %d", resp.StatusCode)
-	}
+			respBody, err = io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Error reading response: %v", err)
+			}
+			if string(respBody) != "AGAIN" {
+				t.Errorf("Expected response body to be AGAIN, got %s", string(respBody))
+			}
+			if resp.Header.Get("Content-Type") != "text/world" {
+				t.Errorf("Expected Content-Type to be text/world, got %s", resp.Header.Get("Content-Type"))
+			}
+			if resp.StatusCode != 200 {
+				t.Errorf("Expected status code to be 200, got %d", resp.StatusCode)
+			}
 	*/
 }

--- a/tunnel/password_test.go
+++ b/tunnel/password_test.go
@@ -1,0 +1,340 @@
+// Copyright (c) 2024 RightScale, Inc. - see LICENSE
+
+package tunnel
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestTokenPasswordValidation tests server-side password validation
+func TestTokenPasswordValidation(t *testing.T) {
+	// Create a test HTTP server that will be proxied
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "Response from test server")
+	}))
+	defer server.Close()
+
+	// Create tunnel server with token passwords
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	serverAddr := listener.Addr().String()
+
+	wstunsrv := NewWSTunnelServer([]string{
+		"-port", "0",
+		"-passwords", "test-token-with-password:secret123,another-token-16chars:password456",
+	})
+
+	wstunsrv.Start(listener)
+	defer wstunsrv.Stop()
+
+	// Wait for server to be ready
+	time.Sleep(100 * time.Millisecond)
+
+	t.Run("AcceptConnectionWithCorrectPassword", func(t *testing.T) {
+		// Create client with password
+		wstuncli := NewWSTunnelClient([]string{
+			"-token", "test-token-with-password:secret123",
+			"-tunnel", "ws://" + serverAddr,
+			"-server", server.URL,
+			"-timeout", "30",
+		})
+		err := wstuncli.Start()
+		if err != nil {
+			t.Fatalf("Failed to start client: %v", err)
+		}
+		defer wstuncli.Stop()
+
+		// Wait for connection
+		time.Sleep(500 * time.Millisecond)
+		if !wstuncli.IsConnected() {
+			t.Errorf("Expected client to be connected. Token: %s, Password: %s", wstuncli.Token, wstuncli.Password)
+		}
+	})
+
+	t.Run("RejectConnectionWithIncorrectPassword", func(t *testing.T) {
+		// Create client with wrong password
+		wstuncli := NewWSTunnelClient([]string{
+			"-token", "test-token-with-password:wrongpassword",
+			"-tunnel", "ws://" + serverAddr,
+			"-server", server.URL,
+			"-timeout", "30",
+		})
+		err := wstuncli.Start()
+		if err != nil {
+			t.Fatalf("Failed to start client: %v", err)
+		}
+		defer wstuncli.Stop()
+
+		// Wait and check that connection is not established
+		time.Sleep(300 * time.Millisecond)
+		if wstuncli.IsConnected() {
+			t.Error("Expected client to not be connected")
+		}
+	})
+
+	t.Run("RejectConnectionWithoutPasswordWhenPasswordIsRequired", func(t *testing.T) {
+		// Create client without password
+		wstuncli := NewWSTunnelClient([]string{
+			"-token", "test-token-with-password",
+			"-tunnel", "ws://" + serverAddr,
+			"-server", server.URL,
+			"-timeout", "30",
+		})
+		err := wstuncli.Start()
+		if err != nil {
+			t.Fatalf("Failed to start client: %v", err)
+		}
+		defer wstuncli.Stop()
+
+		// Wait and check that connection is not established
+		time.Sleep(300 * time.Millisecond)
+		if wstuncli.IsConnected() {
+			t.Error("Expected client to not be connected")
+		}
+	})
+
+	t.Run("AcceptConnectionWithoutPasswordWhenNoPasswordIsConfigured", func(t *testing.T) {
+		// Create client for token without password requirement
+		wstuncli := NewWSTunnelClient([]string{
+			"-token", "test-token-no-password",
+			"-tunnel", "ws://" + serverAddr,
+			"-server", server.URL,
+			"-timeout", "30",
+		})
+		err := wstuncli.Start()
+		if err != nil {
+			t.Fatalf("Failed to start client: %v", err)
+		}
+		defer wstuncli.Stop()
+
+		// Wait for connection
+		time.Sleep(500 * time.Millisecond)
+		if !wstuncli.IsConnected() {
+			t.Errorf("Expected client to be connected. Token: %s, Password: %s", wstuncli.Token, wstuncli.Password)
+		}
+	})
+}
+
+// TestEndToEndWithPassword tests end-to-end functionality with password authentication
+func TestEndToEndWithPassword(t *testing.T) {
+	// Create a test HTTP server that will be proxied
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "Response from test server")
+	}))
+	defer server.Close()
+
+	// Create tunnel server with token passwords
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	serverAddr := listener.Addr().String()
+
+	wstunsrv := NewWSTunnelServer([]string{
+		"-port", "0",
+		"-passwords", "test-token-with-password:secret123",
+	})
+
+	wstunsrv.Start(listener)
+	defer wstunsrv.Stop()
+
+	// Wait for server to be ready
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client with correct password
+	wstuncli := NewWSTunnelClient([]string{
+		"-token", "test-token-with-password:secret123",
+		"-tunnel", "ws://" + serverAddr,
+		"-server", server.URL,
+		"-timeout", "30",
+	})
+	err := wstuncli.Start()
+	if err != nil {
+		t.Fatalf("Failed to start client: %v", err)
+	}
+	defer wstuncli.Stop()
+
+	// Wait for connection
+	time.Sleep(200 * time.Millisecond)
+	if !wstuncli.IsConnected() {
+		t.Fatal("Expected client to be connected")
+	}
+
+	// Make a request through the tunnel
+	resp, err := http.Get(fmt.Sprintf("http://%s/_token/test-token-with-password/test", serverAddr))
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	expected := "Response from test server"
+	if string(body) != expected {
+		t.Errorf("Expected response body to be %q, got %q", expected, string(body))
+	}
+}
+
+// TestServerPasswordParsing tests server password configuration parsing
+func TestServerPasswordParsing(t *testing.T) {
+	t.Run("ParseValidPasswordConfiguration", func(t *testing.T) {
+		args := []string{
+			"-port", "8080",
+			"-passwords", "token12345678901:pass1,token22345678901:pass2,token32345678901:pass3",
+		}
+		srv := NewWSTunnelServer(args)
+		if srv == nil {
+			t.Fatal("Expected server to be created")
+		}
+		if len(srv.tokenPasswords) != 3 {
+			t.Errorf("Expected 3 token passwords, got %d", len(srv.tokenPasswords))
+		}
+		if srv.tokenPasswords[token("token12345678901")] != "pass1" {
+			t.Errorf("Expected token12345678901 password to be 'pass1', got %q", srv.tokenPasswords[token("token12345678901")])
+		}
+		if srv.tokenPasswords[token("token22345678901")] != "pass2" {
+			t.Errorf("Expected token22345678901 password to be 'pass2', got %q", srv.tokenPasswords[token("token22345678901")])
+		}
+		if srv.tokenPasswords[token("token32345678901")] != "pass3" {
+			t.Errorf("Expected token32345678901 password to be 'pass3', got %q", srv.tokenPasswords[token("token32345678901")])
+		}
+	})
+
+	t.Run("HandleMalformedPasswordPairs", func(t *testing.T) {
+		args := []string{
+			"-port", "8080",
+			"-passwords", "token12345678901:pass1,invalid_no_colon,token22345678901:pass2",
+		}
+		srv := NewWSTunnelServer(args)
+		if srv == nil {
+			t.Fatal("Expected server to be created")
+		}
+		if len(srv.tokenPasswords) != 2 {
+			t.Errorf("Expected 2 token passwords (skipping invalid), got %d", len(srv.tokenPasswords))
+		}
+		if srv.tokenPasswords[token("token12345678901")] != "pass1" {
+			t.Errorf("Expected token12345678901 password to be 'pass1', got %q", srv.tokenPasswords[token("token12345678901")])
+		}
+		if srv.tokenPasswords[token("token22345678901")] != "pass2" {
+			t.Errorf("Expected token22345678901 password to be 'pass2', got %q", srv.tokenPasswords[token("token22345678901")])
+		}
+	})
+}
+
+// TestClientPasswordParsing tests client password configuration parsing
+func TestClientPasswordParsing(t *testing.T) {
+	t.Run("TokenWithoutPassword", func(t *testing.T) {
+		args := []string{
+			"-token", "mytoken12345678901",
+			"-tunnel", "ws://localhost:8080",
+		}
+		cli := NewWSTunnelClient(args)
+		if cli == nil {
+			t.Fatal("Expected client to be created")
+		}
+		if cli.Token != "mytoken12345678901" {
+			t.Errorf("Expected token to be 'mytoken12345678901', got %q", cli.Token)
+		}
+		if cli.Password != "" {
+			t.Errorf("Expected password to be empty, got %q", cli.Password)
+		}
+	})
+
+	t.Run("TokenWithPassword", func(t *testing.T) {
+		args := []string{
+			"-token", "mytoken12345678901:mypassword",
+			"-tunnel", "ws://localhost:8080",
+		}
+		cli := NewWSTunnelClient(args)
+		if cli == nil {
+			t.Fatal("Expected client to be created")
+		}
+		if cli.Token != "mytoken12345678901" {
+			t.Errorf("Expected token to be 'mytoken12345678901', got %q", cli.Token)
+		}
+		if cli.Password != "mypassword" {
+			t.Errorf("Expected password to be 'mypassword', got %q", cli.Password)
+		}
+	})
+}
+
+// TestServerPasswordValidation tests the new validation logic for server password configuration
+func TestServerPasswordValidation(t *testing.T) {
+	t.Run("RejectEmptyTokens", func(t *testing.T) {
+		args := []string{
+			"-port", "8080",
+			"-passwords", ":pass1,token12345678901:pass2",
+		}
+		srv := NewWSTunnelServer(args)
+		if srv == nil {
+			t.Fatal("Expected server to be created")
+		}
+		if len(srv.tokenPasswords) != 1 {
+			t.Errorf("Expected 1 token password (skipping empty token), got %d", len(srv.tokenPasswords))
+		}
+		if srv.tokenPasswords[token("token12345678901")] != "pass2" {
+			t.Errorf("Expected token12345678901 password to be 'pass2', got %q", srv.tokenPasswords[token("token12345678901")])
+		}
+	})
+
+	t.Run("RejectEmptyPasswords", func(t *testing.T) {
+		args := []string{
+			"-port", "8080",
+			"-passwords", "token12345678901:,token22345678901:pass2",
+		}
+		srv := NewWSTunnelServer(args)
+		if srv == nil {
+			t.Fatal("Expected server to be created")
+		}
+		if len(srv.tokenPasswords) != 1 {
+			t.Errorf("Expected 1 token password (skipping empty password), got %d", len(srv.tokenPasswords))
+		}
+		if srv.tokenPasswords[token("token22345678901")] != "pass2" {
+			t.Errorf("Expected token22345678901 password to be 'pass2', got %q", srv.tokenPasswords[token("token22345678901")])
+		}
+	})
+
+	t.Run("RejectShortTokens", func(t *testing.T) {
+		args := []string{
+			"-port", "8080",
+			"-passwords", "shorttoken:pass1,token12345678901:pass2",
+		}
+		srv := NewWSTunnelServer(args)
+		if srv == nil {
+			t.Fatal("Expected server to be created")
+		}
+		if len(srv.tokenPasswords) != 1 {
+			t.Errorf("Expected 1 token password (skipping short token), got %d", len(srv.tokenPasswords))
+		}
+		if srv.tokenPasswords[token("token12345678901")] != "pass2" {
+			t.Errorf("Expected token12345678901 password to be 'pass2', got %q", srv.tokenPasswords[token("token12345678901")])
+		}
+	})
+
+	t.Run("WarnOnDuplicateTokens", func(t *testing.T) {
+		args := []string{
+			"-port", "8080",
+			"-passwords", "token12345678901:pass1,token12345678901:pass2",
+		}
+		srv := NewWSTunnelServer(args)
+		if srv == nil {
+			t.Fatal("Expected server to be created")
+		}
+		if len(srv.tokenPasswords) != 1 {
+			t.Errorf("Expected 1 token password (duplicate overwrites), got %d", len(srv.tokenPasswords))
+		}
+		// The second password should overwrite the first
+		if srv.tokenPasswords[token("token12345678901")] != "pass2" {
+			t.Errorf("Expected token12345678901 password to be 'pass2' (overwritten), got %q", srv.tokenPasswords[token("token12345678901")])
+		}
+	})
+}

--- a/tunnel/timeout_test.go
+++ b/tunnel/timeout_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Testing token request timeout", func() {
 			os.Exit(1)
 		}
 		wstunURL = "http://" + listener.Addr().String()
-		for !wstuncli.Connected {
+		for !wstuncli.IsConnected() {
 			time.Sleep(10 * time.Millisecond)
 		}
 	})

--- a/tunnel/xhost_test.go
+++ b/tunnel/xhost_test.go
@@ -74,7 +74,7 @@ waitLoop:
 			// If we time out, just continue - the test will fail if needed
 			break waitLoop
 		case <-ticker.C:
-			if wstuncli.Connected {
+			if wstuncli.IsConnected() {
 				break waitLoop
 			}
 		}
@@ -150,7 +150,7 @@ waitLoop:
 			// If we time out, just continue - the test will fail if needed
 			break waitLoop
 		case <-ticker.C:
-			if wstuncli.Connected {
+			if wstuncli.IsConnected() {
 				break waitLoop
 			}
 		}
@@ -228,7 +228,7 @@ waitLoop:
 			// If we time out, just continue - the test will fail if needed
 			break waitLoop
 		case <-ticker.C:
-			if wstuncli.Connected {
+			if wstuncli.IsConnected() {
 				break waitLoop
 			}
 		}


### PR DESCRIPTION
- Add `-passwords` flag to server for configuring token passwords
- Support `token:password` format in client `-token` flag
- Validate passwords using HTTP Basic Authentication
- Maintain backward compatibility for tokens without passwords

Closes #50
Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for token-specific passwords on server and client sides, enhancing security and access control.
- **Documentation**
  - Updated configuration instructions, usage examples, project overview, and security warnings to reflect password support and best practices.
- **Tests**
  - Added comprehensive tests for password validation, parsing, and authentication flow to ensure robustness.
- **Refactor**
  - Improved control flow and formatting in test files and replaced direct field access with accessor methods for better encapsulation.
- **Security**
  - Implemented optional password verification for tokens with constant-time comparison to mitigate timing attacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->