### PR TITLE
feat: add Android support with documentation and build configuration

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,13 +1,14 @@
 # ChangeLog
 
 {{ range .Versions -}}
-## {{ if .Tag.Previous }}[{{ .Tag.Name -}}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
+## {{ if .Tag.Previous }}[{{ .Tag.Name -}}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
 
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 
 {{ range .Commits -}}
-* {{ .Subject }}
+* {{- if .Scope }} **{{ .Scope }}**: {{ end -}}
+{{ .Subject }} ([{{ .Hash.Short }}]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }}))
 {{ end }}
 {{ end -}}
 

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -5,23 +5,37 @@ info:
   repository_url: https://github.com/rshade/wstunnel
 options:
   commits:
-    # filters:
-    #   Type:
-    #     - feat
-    #     - fix
-    #     - perf
-    #     - refactor
+    filters:
+      Type:
+        - feat
+        - fix
+        - perf
+        - refactor
+        - docs
+        - style
+        - test
+        - chore
+        - build
+        - ci
   commit_groups:
-    # title_maps:
-    #   feat: Features
-    #   fix: Bug Fixes
-    #   perf: Performance Improvements
-    #   refactor: Code Refactoring
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+      docs: Documentation
+      style: Style Changes
+      test: Tests
+      chore: Chores
+      build: Build System
+      ci: CI/CD
   header:
-    pattern: "^((\\w+)\\s.*)$"
+    pattern: "^(\\w+)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
     pattern_maps:
-      - Subject
       - Type
+      - Scope
+      - Subject
   notes:
     keywords:
       - BREAKING CHANGE
+      - BREAKING CHANGES

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,12 +19,17 @@ builds:
       - darwin
       - windows
       - linux
+      - android
     ignore:
       - goos: windows
         goarch: arm64
       - goos: windows
         goarch: 386
       - goos: darwin
+        goarch: 386
+      - goos: android
+        goarch: amd64
+      - goos: android
         goarch: 386
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,178 +1,66 @@
 # ChangeLog
 
-## [Unreleased]
+## [v1.1.1](https://github.com/rshade/wstunnel/compare/1.0.7...v1.1.1) (2025-04-21)
 
-### Add
+### Bug Fixes
 
-* Add support for per-token passwords for enhanced security (#50)
-  - Server: Use `-passwords 'token1:password1,token2:password2'` to require passwords for specific tokens
-  - Client: Use `-token 'mytoken:mypassword'` to authenticate with a password
+*Updating release for permissions ([#111](https://github.com/rshade/wstunnel/issues/111)) ([3b1636b](https://github.com/rshade/wstunnel/commit/3b1636b297dcada2d2e4b1e6d37431d75083abf9))
+* **deps**: update module github.com/onsi/ginkgo to v2 ([#52](https://github.com/rshade/wstunnel/issues/52)) ([a822b86](https://github.com/rshade/wstunnel/commit/a822b86c96e653b4f3d649e4271c4e58f5f8f4e2))
 
-### Fix
+### Chores
 
-* Fix timeout of requests to _token endpoint (#3)
-
-## [v1.1.0](https://github.com/rshade/wstunnel/compare/1.0.7...v1.1.0)
-
-### Add
-
-* Add client parameter -certfile to provide certificate to trust
-* Add support for Basic auth in client's tunnel URL ([#60](https://github.com/rshade/wstunnel/issues/60))
-
-### Adding
-
-* adding key lower
-* adding in build files ([#3](https://github.com/rshade/wstunnel/issues/3))
-
-### Adding
-
-* Adding in Changelog ([#53](https://github.com/rshade/wstunnel/issues/53))
-* Adding Changelog, Changelog Generator, Fixing Client-Ports Usage, Updating to golang 1.14.x ([#39](https://github.com/rshade/wstunnel/issues/39))
-* Adding instructions for WSL ([#43](https://github.com/rshade/wstunnel/issues/43))
-
-### Automerge
-
-* automerge ([#51](https://github.com/rshade/wstunnel/issues/51))
-
-### Bump
-
-* Bump github.com/onsi/gomega from 1.35.1 to 1.36.2 ([#42](https://github.com/rshade/wstunnel/issues/42))
-* Bump github.com/onsi/gomega from 1.34.2 to 1.35.1 ([#39](https://github.com/rshade/wstunnel/issues/39))
-* Bump github.com/onsi/gomega from 1.34.1 to 1.34.2 ([#37](https://github.com/rshade/wstunnel/issues/37))
-* Bump github.com/gorilla/websocket from 1.5.1 to 1.5.3 ([#32](https://github.com/rshade/wstunnel/issues/32))
-* Bump github.com/onsi/gomega from 1.31.1 to 1.34.1 ([#34](https://github.com/rshade/wstunnel/issues/34))
-* Bump golang.org/x/net from 0.20.0 to 0.23.0 ([#30](https://github.com/rshade/wstunnel/issues/30))
-* Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 ([#29](https://github.com/rshade/wstunnel/issues/29))
-* Bump github.com/onsi/gomega from 1.27.4 to 1.28.0 ([#27](https://github.com/rshade/wstunnel/issues/27))
-* Bump gopkg.in/inconshreveable/log15.v2 from 2.0.0-20200109203555-b30bc20e4fd1 to 2.16.0 ([#19](https://github.com/rshade/wstunnel/issues/19))
-* Bump github.com/onsi/gomega from 1.24.1 to 1.27.4 ([#22](https://github.com/rshade/wstunnel/issues/22))
-* Bump github.com/onsi/gomega from 1.19.0 to 1.24.1 ([#13](https://github.com/rshade/wstunnel/issues/13))
-* Bump github.com/onsi/gomega from 1.17.0 to 1.19.0
-* Bump github.com/gorilla/websocket from 1.4.2 to 1.5.0
-* Bump github.com/onsi/gomega from 1.16.0 to 1.17.0 ([#59](https://github.com/rshade/wstunnel/issues/59))
-* Bump github.com/onsi/ginkgo from 1.16.4 to 1.16.5 ([#58](https://github.com/rshade/wstunnel/issues/58))
-* Bump github.com/onsi/gomega from 1.15.0 to 1.16.0 ([#57](https://github.com/rshade/wstunnel/issues/57))
-
-### Cmpfusion
-
-* Cmpfusion 176 upgrade websocket golang116 ([#54](https://github.com/rshade/wstunnel/issues/54))
-
-### Configure
-
-* Configure Renovate ([#43](https://github.com/rshade/wstunnel/issues/43))
-
-### Create
-
-* Create go.yml
-
-### Fix
-
-* fix broken WSTunnelClient Stop() ([#52](https://github.com/rshade/wstunnel/issues/52))
-
-### Go
-
-* Go Mod Tidy
-
-### Mapero
-
-* Mapero upstream ([#28](https://github.com/rshade/wstunnel/issues/28))
-
-### Merge
-
-* merge conflicts
-
-### Merge
-
-* Merge branch 'master' into dependabot/go_modules/github.com/gorilla/websocket-1.5.0
-
-### Pinning
-
-* pinning mergo
-
-### Release
-
-* release 1.1.0
-
-### Remove
-
-* remove make depend
-
-### Replace
-
-* replace recently introduced sync.WaitGroup with sync.Cond ([#35](https://github.com/rshade/wstunnel/issues/35)) ([#36](https://github.com/rshade/wstunnel/issues/36))
-
-### Set
-
-* Set InsecureSkipVerify in gorillas websocket Dialer too, if -insecure is set ([#61](https://github.com/rshade/wstunnel/issues/61))
-
-### Update
-
-* Update module github.com/onsi/ginkgo to v2 ([#50](https://github.com/rshade/wstunnel/issues/50))
-* Update goreleaser/goreleaser-action action to v6 ([#49](https://github.com/rshade/wstunnel/issues/49))
-* Update golang Docker tag to v1.23 ([#48](https://github.com/rshade/wstunnel/issues/48))
-* Update actions/setup-go action to v5.3.0 ([#45](https://github.com/rshade/wstunnel/issues/45))
-* Update module dario.cat/mergo to v1.0.1 ([#44](https://github.com/rshade/wstunnel/issues/44))
-
-### Updating
-
-* Updating for releases ([#47](https://github.com/rshade/wstunnel/issues/47))
-* Updating WSL.md adding sudo ([#44](https://github.com/rshade/wstunnel/issues/44))
-
-### Use
-
-* Use io.Reader to avoid file size limits ([#26](https://github.com/rshade/wstunnel/issues/26))
+*fix golanglint items ([#66](https://github.com/rshade/wstunnel/issues/66)) ([eff2d08](https://github.com/rshade/wstunnel/commit/eff2d088e1cacb95184b57b4e5573a338422546f))
+* **deps**: Update golangci/golangci-lint-action action to v6.4.0 ([#81](https://github.com/rshade/wstunnel/issues/81)) ([5f0d1f5](https://github.com/rshade/wstunnel/commit/5f0d1f56d286e3aeba66a0dedad28cb0345e684b))
+* **deps**: Update module golang.org/x/tools to v0.32.0 ([#108](https://github.com/rshade/wstunnel/issues/108)) ([7dbab48](https://github.com/rshade/wstunnel/commit/7dbab48dd2667456146b5241d76e9e7d2c2dacfb))
+* **deps**: Update module golang.org/x/net to v0.39.0 ([#107](https://github.com/rshade/wstunnel/issues/107)) ([1d73d9c](https://github.com/rshade/wstunnel/commit/1d73d9cb2c4cf666d2284a1b660308201cc2caf4))
+* **deps**: Update all non-major go dependencies ([#106](https://github.com/rshade/wstunnel/issues/106)) ([dc021f3](https://github.com/rshade/wstunnel/commit/dc021f3f955f343bdd399b60571e4e62b958ef50))
+* **deps**: Update module github.com/onsi/gomega to v1.37.0 ([#104](https://github.com/rshade/wstunnel/issues/104)) ([5ad872d](https://github.com/rshade/wstunnel/commit/5ad872d6589f3b6dbf2b4d19fd64eb299c0e45ae))
+* **deps**: Update dependency go to v1.24.2 ([#102](https://github.com/rshade/wstunnel/issues/102)) ([9b022b3](https://github.com/rshade/wstunnel/commit/9b022b3c4debba045b8c112d09f41860170496e2))
+* **deps**: Update goreleaser/goreleaser-action action to v6.3.0 ([#101](https://github.com/rshade/wstunnel/issues/101)) ([29b0897](https://github.com/rshade/wstunnel/commit/29b089789c49ef460444d2d9ff3f0490609dadfb))
+* **deps**: Update module golang.org/x/net to v0.38.0 ([#100](https://github.com/rshade/wstunnel/issues/100)) ([19eadb8](https://github.com/rshade/wstunnel/commit/19eadb8b4c0620b0b532223cca043d18c5a1229f))
+* **deps**: Update module google.golang.org/protobuf to v1.36.6 ([#98](https://github.com/rshade/wstunnel/issues/98)) ([5fe082d](https://github.com/rshade/wstunnel/commit/5fe082d40f559a91baa1068d5f3a9d6f6abae2e1))
+* **deps**: Update all non-major go dependencies ([#97](https://github.com/rshade/wstunnel/issues/97)) ([1e767ca](https://github.com/rshade/wstunnel/commit/1e767cabfbd913192b81577439ceb4961e13dfb8))
+* **deps**: Update module github.com/onsi/ginkgo/v2 to v2.23.2 ([#96](https://github.com/rshade/wstunnel/issues/96)) ([89b621f](https://github.com/rshade/wstunnel/commit/89b621f2ec55b13b1532199a2cccfc858cc50bc1))
+* **deps**: Update actions/setup-go action to v5.4.0 ([#94](https://github.com/rshade/wstunnel/issues/94)) ([cf8840f](https://github.com/rshade/wstunnel/commit/cf8840f3b8300ef60722d6a162945a87225170fa))
+* **deps**: Update module github.com/onsi/ginkgo/v2 to v2.23.1 ([#93](https://github.com/rshade/wstunnel/issues/93)) ([8f30115](https://github.com/rshade/wstunnel/commit/8f3011578e8f031151ee84a49aa698f81dae139b))
+* **deps**: Update golangci/golangci-lint-action action to v6.5.2 ([#91](https://github.com/rshade/wstunnel/issues/91)) ([66caf23](https://github.com/rshade/wstunnel/commit/66caf23ece33460654445964f0846003c20ff220))
+* **deps**: Update golangci/golangci-lint-action action to v6.5.1 ([#90](https://github.com/rshade/wstunnel/issues/90)) ([3f1cfe3](https://github.com/rshade/wstunnel/commit/3f1cfe3c0e2ddb98197f8cd357ee7170786cf4cc))
+* **deps**: Update dependency go to 1.24 ([#89](https://github.com/rshade/wstunnel/issues/89)) ([bf34801](https://github.com/rshade/wstunnel/commit/bf3480158225f94e2839c4c89f4f655bc75e42e2))
+* **deps**: Update all non-major go dependencies ([#88](https://github.com/rshade/wstunnel/issues/88)) ([2e4a5ec](https://github.com/rshade/wstunnel/commit/2e4a5ecdc4a12f5c6ec8073056432a4fcd2d43a4))
+* **deps**: Update module golang.org/x/net to v0.36.0 ([#86](https://github.com/rshade/wstunnel/issues/86)) ([36fe979](https://github.com/rshade/wstunnel/commit/36fe979c5b1792fa03ef1ad1af825543209ea2ac))
+* **deps**: Update module github.com/google/go-cmp to v0.7.0 ([#84](https://github.com/rshade/wstunnel/issues/84)) ([238d2bb](https://github.com/rshade/wstunnel/commit/238d2bb1f43c483c2a24004628be0307a192bee4))
+* **deps**: Update golangci/golangci-lint-action action to v6.5.0 ([#83](https://github.com/rshade/wstunnel/issues/83)) ([74da77c](https://github.com/rshade/wstunnel/commit/74da77c729afd87a1829c6da55ca6d7949b14d70))
+* **deps**: Update golang Docker tag to v1.24 ([#80](https://github.com/rshade/wstunnel/issues/80)) ([54027d6](https://github.com/rshade/wstunnel/commit/54027d68bdfae9de277eb53a8a1c5ed6f10940bb))
+* **deps**: Update golangci/golangci-lint-action action to v6.4.1 ([#82](https://github.com/rshade/wstunnel/issues/82)) ([1755b2c](https://github.com/rshade/wstunnel/commit/1755b2cfa8e5c4fd8a3085788cc164646ec05f4a))
+* **deps**: Update github.com/google/pprof digest to 24c5476 ([#85](https://github.com/rshade/wstunnel/issues/85)) ([29bb281](https://github.com/rshade/wstunnel/commit/29bb281ee46fe5689d4556b9cf4666d0f8ca68bf))
+* **deps**: Update module golang.org/x/tools to v0.30.0 ([#79](https://github.com/rshade/wstunnel/issues/79)) ([4e44feb](https://github.com/rshade/wstunnel/commit/4e44feb9fa04066c3b398a91b67f287acbe61cdf))
+* **deps**: Update goreleaser/goreleaser-action action to v6.2.1 ([#78](https://github.com/rshade/wstunnel/issues/78)) ([3a747f3](https://github.com/rshade/wstunnel/commit/3a747f31983a9bf52b356dec56600b3dee6f1b35))
+* **deps**: Update github.com/google/pprof digest to d0013a5 ([#73](https://github.com/rshade/wstunnel/issues/73)) ([d4917ac](https://github.com/rshade/wstunnel/commit/d4917acd645d00f369b9b9c6bbb99fc9dbbe23fc))
+* **deps**: Update module golang.org/x/net to v0.35.0 ([#77](https://github.com/rshade/wstunnel/issues/77)) ([9497899](https://github.com/rshade/wstunnel/commit/9497899810f4c0987c321a7739158bbb43b23b3a))
+* **deps**: Update golangci/golangci-lint-action action to v6.3.2 ([#76](https://github.com/rshade/wstunnel/issues/76)) ([9f17f1a](https://github.com/rshade/wstunnel/commit/9f17f1a9944c9a417f7b4ddfb7219d66f8653d8c))
+* **deps**: Update golangci/golangci-lint-action action to v6.3.1 ([#74](https://github.com/rshade/wstunnel/issues/74)) ([fcad4a3](https://github.com/rshade/wstunnel/commit/fcad4a31a9b36e26dc854e722ebd15b474914cc6))
+* **deps**: Update github.com/google/pprof digest to fc31438 ([#70](https://github.com/rshade/wstunnel/issues/70)) ([816205c](https://github.com/rshade/wstunnel/commit/816205c2cb992e480fd15a465ac55dceeb1172f9))
+* **deps**: migrate renovate config ([#72](https://github.com/rshade/wstunnel/issues/72)) ([46c9585](https://github.com/rshade/wstunnel/commit/46c95857e8def36e98356cd0ce5bdcbaf60676c2))
+* **deps**: Update all non-major go dependencies ([#71](https://github.com/rshade/wstunnel/issues/71)) ([ff7492a](https://github.com/rshade/wstunnel/commit/ff7492af1f0bff7527d7662efc97772354ae6c99))
+* **deps**: update codecov/codecov-action action to v3.1.6 ([#58](https://github.com/rshade/wstunnel/issues/58)) ([113d64e](https://github.com/rshade/wstunnel/commit/113d64e35c774c5217edef5e2c2ecff8f56c2725))
+* **deps**: update goreleaser/goreleaser-action action to v6 ([#65](https://github.com/rshade/wstunnel/issues/65)) ([38a50df](https://github.com/rshade/wstunnel/commit/38a50df30ca409ad0504e4a016ef0eefcf3fb913))
+* **deps**: update golangci/golangci-lint-action action to v3.7.1 ([#59](https://github.com/rshade/wstunnel/issues/59)) ([5168b9e](https://github.com/rshade/wstunnel/commit/5168b9eb5331c1ac69f097db5d8e2678bfd05270))
+* **deps**: update golangci/golangci-lint-action action to v6 ([#64](https://github.com/rshade/wstunnel/issues/64)) ([8a50443](https://github.com/rshade/wstunnel/commit/8a504432d8132f2382f3f3736e8446f004fbcbf2))
+* **deps**: update codecov/codecov-action action to v5 ([#63](https://github.com/rshade/wstunnel/issues/63)) ([72049e4](https://github.com/rshade/wstunnel/commit/72049e4d18f6e74625708ae38ae7557196bb9f5c))
+* **deps**: Update golangci/golangci-lint-action action to v7 ([#99](https://github.com/rshade/wstunnel/issues/99)) ([d6aae6e](https://github.com/rshade/wstunnel/commit/d6aae6ece1c1c8ce3e1026d9a61dcd4b84d4c138))
+* **deps**: update goreleaser/goreleaser-action action to v5.1.0 ([#62](https://github.com/rshade/wstunnel/issues/62)) ([93156b1](https://github.com/rshade/wstunnel/commit/93156b128ac305b28d913915a71847645e93f780))
+* **deps**: update actions/setup-go action to v5.3.0 ([#61](https://github.com/rshade/wstunnel/issues/61)) ([bc7aaa5](https://github.com/rshade/wstunnel/commit/bc7aaa589ee6b9ac3d453d518681ca1393b79a4c))
+* **deps**: update actions/checkout action to v4.2.2 ([#60](https://github.com/rshade/wstunnel/issues/60)) ([7edae01](https://github.com/rshade/wstunnel/commit/7edae01dc551763df2acfeaed93f81d2c2add502))
+* **renovate**: updating renovate.json for best practices ([#68](https://github.com/rshade/wstunnel/issues/68)) ([d144400](https://github.com/rshade/wstunnel/commit/d144400b5e2ba6ff1549f031c9a7e042311496c1))
+* **renovate**: updating renovate.json for best practices, fixes [#67](https://github.com/rshade/wstunnel/issues/67) ([#69](https://github.com/rshade/wstunnel/issues/69)) ([02cc811](https://github.com/rshade/wstunnel/commit/02cc8110b4c11f255e4e940d439437b319c5b7d2))
+* **tools**: Adding in coverage ([#57](https://github.com/rshade/wstunnel/issues/57)) ([37dd82f](https://github.com/rshade/wstunnel/commit/37dd82f7df0f962f133250802620e72f3feac518))
 
 ### Pull Requests
 
 * Merge pull request [#1](https://github.com/rshade/wstunnel/issues/1) from rshade/dependabot/go_modules/github.com/gorilla/websocket-1.5.0
 * Merge pull request [#2](https://github.com/rshade/wstunnel/issues/2) from rshade/dependabot/go_modules/github.com/onsi/gomega-1.19.0
 
-## [1.0.7](https://github.com/rshade/wstunnel/compare/1.0.6...1.0.7)
-
-### Add
-
-* Add Support for Wstuncli port range ([#35](https://github.com/rshade/wstunnel/issues/35))
-* Add support for binding to the specific host ([#23](https://github.com/rshade/wstunnel/issues/23)) ([#36](https://github.com/rshade/wstunnel/issues/36))
-* Add windows support.
-* Add ginkgo binary as a dependency
-* Add comments to readme
-
-### Build
-
-* Build and Upload, fixes [#34](https://github.com/rshade/wstunnel/issues/34) ([#38](https://github.com/rshade/wstunnel/issues/38))
-
-### Correct
-
-* Correct protocol for tunserv
-
-### Fix
-
-* Fix Travis CI harder
-* Fix Makefile to work under Windows/Cygwin
-* Fix typo in README
-* Fix minor documentation bugs
-
-### Make
-
-* Make GoLint Happy ([#37](https://github.com/rshade/wstunnel/issues/37))
-* Make Travis CI happy as well as the Windows build
-* Make version.go editing work for Travis
-
-### Merge
-
-* Merge branch 'master' into patch-1
-
-### Removing
-
-* Removing the reference to HTTPS not supported.
-
-### Switch
-
-* Switch from Godep to dep
-
-### Updated
-
-* updated readme for latest version
+## [1.0.7](https://github.com/rshade/wstunnel/compare/1.0.6...1.0.7) (2019-11-05)
 
 ### Pull Requests
 
@@ -181,284 +69,23 @@
 * Merge pull request [#28](https://github.com/rshade/wstunnel/issues/28) from rightscale/ph-update-dependencies
 * Merge pull request [#25](https://github.com/rshade/wstunnel/issues/25) from flaccid/patch-1
 
-## [1.0.6](https://github.com/rshade/wstunnel/compare/1.0.5...1.0.6)
+## [1.0.6](https://github.com/rshade/wstunnel/compare/1.0.5...1.0.6) (2019-11-05)
 
-### Add
-
-* add tests to large requests and responses
-
-### Dump
-
-* dump req/resp in case of error, try 2
-* dump req/resp in case of error
-
-### Fix
-
-* fix tests not to print to stderr
-* fix race condition when reading long messages from websocket in wstuncli
-* fix new-websocket race in wstuncli
-
-### Try
-
-* try to fix test race condition [#2](https://github.com/rshade/wstunnel/issues/2)
-* try to fix test race condition
-
-### Tweak
-
-* tweak debug output
-
-## [1.0.5](https://github.com/rshade/wstunnel/compare/1.0.4...1.0.5)
-
-### Added
-
-* added logging to track ws connect/disconnect
-
-### Fix
-
-* fix error propagation in wsReader
-* fix request timeout calculation
-* fix panics when pings fail
-
-### Logging
-
-* logging tweak
-
-### Try
-
-* try to fix random test failures
-
-### Tweak
-
-* tweak readme
+## [1.0.5](https://github.com/rshade/wstunnel/compare/1.0.4...1.0.5) (2019-11-05)
 
 ### Pull Requests
 
 * Merge pull request [#16](https://github.com/rshade/wstunnel/issues/16) from rightscale/IV-2077_proxy
 
-## [1.0.4](https://github.com/rshade/wstunnel/compare/1.0.3...1.0.4)
+## [1.0.4](https://github.com/rshade/wstunnel/compare/1.0.3...1.0.4) (2019-11-05)
 
-### Attempt
+## [1.0.3](https://github.com/rshade/wstunnel/compare/1.0.2...1.0.3) (2019-11-05)
 
-* attempt to test websocket reconnection
+## [1.0.2](https://github.com/rshade/wstunnel/compare/1.0.1...1.0.2) (2019-11-05)
 
-### Fix
+## [1.0.1](https://github.com/rshade/wstunnel/compare/1.0.0...1.0.1) (2019-11-05)
 
-* fix FD leak in wstuncli; add test
-
-### Update
-
-* update readme
-
-## [1.0.3](https://github.com/rshade/wstunnel/compare/1.0.2...1.0.3)
-
-### Fix
-
-* fix non-remove requests on tunnel abort; fix non-reopening of WS at client
-
-## [1.0.2](https://github.com/rshade/wstunnel/compare/1.0.1...1.0.2)
-
-### Added
-
-* added statusfile option
-
-### Readme
-
-* readme fix
-
-### Tweak
-
-* tweak readme
-
-## [1.0.1](https://github.com/rshade/wstunnel/compare/1.0.0...1.0.1)
-
-### Add
-
-* add more debug info to x-host match failure
-
-### Better
-
-* better non-existent tunnel handling
-
-### Change
-
-* change syslog to LogFormatter, which isn't great either
-
-### Fix
-
-* fix recursive code coverage
-
-### Makefile
-
-* makefile fix 4
-* makefile fix 3
-* makefile fix 2
-* makefile fix
-
-### Support
-
-* support syslog on client; improve syslog log format
-
-### Updated
-
-* updated readme
-
-## 1.0.0
-
-### Acu152721
-
-* acu152721 use exec su, since setuid is forced on pre-start
-* acu152721 Have upstart use the www-data user
-
-### Add
-
-* add godeps
-
-### Added
-
-* added upstart config files to tgz
-* added support for internal servers
-* added more tests
-* added log15 dependency, added missing test file
-* added upload to S3 to makefile, removed binaries from git
-* added whois lookup to tunnel endpoint IP addresses
-* added stats request; added explicit GC
-* added health check; fixed wstunsrv upstart config
-* added upstart conf for wstunsrv and minor edit to wstuncli.conf
-* added ubuntu upstart and config, license, and binaries
-
-### Created
-
-* created tunnel package
-
-### Delete
-
-* Delete README.md
-
-### First
-
-* first passing test
-* first working version
-
-### Fix
-
-* fix cmdline parsing
-* fix async AbortConnection
-* fix test suite and coverprofile
-* fix host header
-* fix x-host error responses; add test cases
-* fix code coverage badge
-* fix travis.yml
-* fix go vet booboo
-* fix govet complaints
-* fix version
-* fix readme
-* fix some more logging
-* fix some more logging
-* fix whois regexp
-* fix deadlock in stats handler; add reverse DNS lookup for tunnels
-* fix problems with chunked encoding and other transfer encodings
-* fix problems with chunked encoding and other transfer encodings
-* fix readme headings
-
-### Fixed
-
-* fixed FD leak; added syslog flag; added tunnel keys; sanitize tokens from log
-* fixed README instructions
-
-### Godep
-
-* godep hell
-
-### Improved
-
-* improved test for host header
-* improved logging; removed read/write timeouts due to bug
-
-### Initial
-
-* Initial commit
-
-### Made
-
-* made x-host header work
-
-### Makefile
-
-* makefile tweak
-* makefile tweak
-* makefile tweak
-* makefile tweak
-
-### Merge
-
-* Merge branch 'master' of github.com:rightscale/wstunnel
-* Merge branch 'master' of github.com:rightscale/wstunnel
-* Merge branch 'master' of github.com:rightscale/wstunnel
-
-### Merge
-
-* merge client & server into a single main
-
-### More
-
-* more debugging for wstuncli errors; inadvertant gofmt
-
-### More
-
-* More readme changes
-
-### Remove
-
-* remove wstunsrv binary again
-* remove read/write timeouts on socket; fix logging typo
-
-### Removed
-
-* Removed logfile and added syslog options
-
-### Removed
-
-* removed default for -server option
-
-### Restrict
-
-* restrict _stats to localhost; improve whois parsing; add minimum token length; print error on failed tunnel connect
-
-### Run
-
-* run gofmt
-
-### Squash
-
-* squash file descriptor leak in wstunsrv
-
-### Start
-
-* start on runlevel 2 as well
-
-### Started
-
-* started to update readme
-
-### Timeout
-
-* timeout tweaks, recompile to get go1.3 timeout fixes
-
-### Travis
-
-* travis support
-
-### Update
-
-* Update README.md
-
-### Updated
-
-* updated README
-
-### Version
-
-* version and logging tweaks
+## 1.0.0 (2019-11-05)
 
 ### Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ WStunnel is a WebSocket-based reverse HTTP/HTTPS tunneling solution that enables
 
 ## Test Commands 
 - `make test` - Run all tests with coverage
-- `ginkgo -focus="<test description>" ./tunnel` - Run a single test
-- `ginkgo -r -noColor` - Run tests without colors
+- `go test -run="<test name>" ./tunnel` - Run a single test
+- `go test ./...` - Run all tests in the project
 
 ## Lint Commands
 - `make lint` - Run gofmt check and go vet
@@ -29,7 +29,7 @@ WStunnel is a WebSocket-based reverse HTTP/HTTPS tunneling solution that enables
 - **Naming**: PascalCase for exported, camelCase for unexported, snake_case for files
 - **Error Handling**: Check errors immediately, return to caller or log with context
 - **Logging**: Use log15 with structured key-value pairs
-- **Tests**: Use Ginkgo BDD-style tests with Gomega assertions
+- **Tests**: Use standard Go testing with table-driven tests
 - **Blank Identifiers**: Don't use unused blank identifiers like `var _ fmt.Formatter`
 - **Go Version**: Use `go 1.24` format in go.mod (not `go 1.24.0`)
 
@@ -51,6 +51,8 @@ WStunnel is a WebSocket-based reverse HTTP/HTTPS tunneling solution that enables
 - Tests cover authentication, proxies, failures, timeouts, concurrent requests
 - Use `testutil.TestLogLevel()` to control log verbosity in tests
 - Port allocation uses `:0` to get random available ports
+- Use standard Go testing package with table-driven tests
+- Test files should be named `*_test.go` and placed alongside the code they test
 
 ## Security Considerations
 - Tokens must be at least 16 characters
@@ -69,3 +71,12 @@ WStunnel is a WebSocket-based reverse HTTP/HTTPS tunneling solution that enables
 - The application has no `-version` flag, check version in the generated `version.go` file
 - WebSocket ping/pong failures often indicate network issues or proxy interference
 - Request timeouts can be tuned with `-timeout` flag (default 30s)
+
+## CodeRabbit Review Settings
+The project uses CodeRabbit for automated code reviews (see `.coderabbit.yaml`). When writing code, ensure compliance with:
+- **Go conventions**: Use gofmt, organize imports (stdlib first), proper error handling
+- **Security**: Never log passwords/tokens, validate certificates, prevent timing attacks
+- **Testing**: Use standard Go testing with table-driven tests, cover edge cases
+- **Path-specific rules**: WebSocket code must follow patterns in tunnel/ws.go, use goroutine-per-request
+- **Excluded paths**: vendor/, build/, node_modules/, generated code, coverage.txt are not reviewed
+- CodeRabbit auto-approves dependency updates from Renovate and documentation-only changes

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Makefile for Golang projects, v0.9.0
 #
 # Features:
-# - runs ginkgo tests recursively, computes code coverage report
+# - runs go tests recursively, computes code coverage report
 # - code coverage ready for travis-ci to upload and produce badges for README.md
 # - build for linux/amd64, linux/arm, darwin/amd64, windows/amd64
 # - just 'make' builds for local OS/arch

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/rshade/wstunnel?utm_source=oss&utm_medium=github&utm_campaign=rshade%2Fwstunnel&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 - Master:
-[![Build Status](https://travis-ci.org/rightscale/wstunnel.svg?branch=master)](https://travis-ci.org/rightscale/wstunnel)
-[![Coverage](https://s3.amazonaws.com/rs-code-coverage/wstunnel/cc_badge_master.svg)](https://gocover.io/github.com/rightscale/wstunnel)
-- 1.0.7:
-[![Build Status](https://travis-ci.org/rightscale/wstunnel.svg?branch=1.0.7)](https://travis-ci.org/rightscale/wstunnel)
-[![Coverage](https://s3.amazonaws.com/rs-code-coverage/wstunnel/cc_badge_1.0.7.svg)](https://gocover.io/github.com/rightscale/wstunnel)
+[![Build Status](https://github.com/rshade/wstunnel/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/rshade/wstunnel/actions/workflows/go.yml)
+[![Coverage](https://codecov.io/gh/rshade/wstunnel/branch/master/graph/badge.svg)](https://app.codecov.io/gh/rshade/wstunnel)
+- 1.1.1:
+[![Build Status](https://github.com/rshade/wstunnel/actions/workflows/go.yml/badge.svg?branch=1.1.1)](https://github.com/rshade/wstunnel/actions/workflows/go.yml)
+[![Coverage](https://codecov.io/gh/rshade/wstunnel/branch/1.1.1/graph/badge.svg)](https://app.codecov.io/gh/rshade/wstunnel)
 
 WStunnel creates an HTTPS tunnel that can connect servers sitting
 behind an HTTP proxy and firewall to clients on the internet. It differs from many other projects
@@ -156,6 +156,10 @@ $ curl 'https://wstun.example.com:8080/_token/my_b!g_$secret!!/some/web/page'
 $ curl '-HX-Token:my_b!g_$secret!!' https://wstun.example.com:8080/some/web/page
 <html> .......
 ```
+
+### Running on Android
+
+WStunnel can be run on Android devices using terminal emulators like Termux. See the [Android documentation](docs/ANDROID.md) for detailed setup instructions.
 
 ### Targeting multiple web servers
 

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -1,0 +1,160 @@
+# Using WStunnel on Android
+
+WStunnel can be run on Android devices using a terminal emulator. This guide explains how to set up and use WStunnel as a client on Android.
+
+## Prerequisites
+
+1. **Terminal Emulator**: Install a terminal app from Google Play Store:
+   - [Termux](https://termux.com/) (Recommended)
+   - [Terminal Emulator for Android](https://play.google.com/store/apps/details?id=jackpal.androidterm)
+
+2. **Root Access**: Not required for basic usage, but may be needed for certain network operations.
+
+## Installation Methods
+
+### Method 1: Download Pre-built Binary (Recommended)
+
+1. Open your terminal emulator (e.g., Termux)
+
+2. Download the Android ARM64 binary:
+   ```bash
+   # For ARM64 devices (most modern phones)
+   wget https://github.com/rshade/wstunnel/releases/latest/download/wstunnel_1.1.1_android_arm64.tar.gz
+   
+   # Extract the binary
+   tar -xzf wstunnel_1.1.1_android_arm64.tar.gz
+   
+   # Make it executable
+   chmod +x wstunnel
+   ```
+
+3. Move to a directory in PATH (optional):
+   ```bash
+   mkdir -p $HOME/bin
+   mv wstunnel $HOME/bin/
+   export PATH=$HOME/bin:$PATH
+   ```
+
+### Method 2: Build from Source
+
+If you have Go installed on your Android device (via Termux):
+
+```bash
+# Install dependencies in Termux
+pkg update
+pkg install golang git
+
+# Clone and build
+git clone https://github.com/rshade/wstunnel.git
+cd wstunnel
+go build -o wstunnel .
+```
+
+## Usage
+
+### Basic Client Setup
+
+1. Connect to your WStunnel server:
+   ```bash
+   ./wstunnel cli \
+     -tunnel ws://your-server.com:8080 \
+     -server http://localhost:8080 \
+     -token 'your_secret_token'
+   ```
+
+2. For secure connections (WSS):
+   ```bash
+   ./wstunnel cli \
+     -tunnel wss://your-server.com:443 \
+     -server http://localhost:8080 \
+     -token 'your_secret_token'
+   ```
+
+### Running in Background
+
+To keep WStunnel running when you close the terminal:
+
+```bash
+# Using nohup
+nohup ./wstunnel cli -tunnel ws://server:8080 -server http://localhost:8080 -token 'token' &
+
+# Or using Termux's wake-lock to prevent Android from killing the process
+termux-wake-lock
+./wstunnel cli -tunnel ws://server:8080 -server http://localhost:8080 -token 'token'
+```
+
+### Auto-start on Boot (Termux)
+
+1. Create a startup script:
+   ```bash
+   mkdir -p ~/.termux/boot/
+   cat > ~/.termux/boot/start-wstunnel.sh << 'EOF'
+   #!/data/data/com.termux/files/usr/bin/sh
+   termux-wake-lock
+   $HOME/bin/wstunnel cli \
+     -tunnel ws://your-server:8080 \
+     -server http://localhost:8080 \
+     -token 'your_token' \
+     >> $HOME/wstunnel.log 2>&1
+   EOF
+   chmod +x ~/.termux/boot/start-wstunnel.sh
+   ```
+
+2. Install Termux:Boot app from F-Droid to enable boot scripts.
+
+## Connecting Through Android Apps
+
+Once WStunnel is running, you can use it with Android apps that support HTTP proxies:
+
+1. **Local Proxy Setup**: Run WStunnel to forward to a local proxy port
+2. **Configure Apps**: Set your apps to use `localhost` and the configured port as HTTP proxy
+
+## Battery Optimization
+
+Android may kill background processes to save battery. To prevent this:
+
+1. **Termux**: Use `termux-wake-lock` command
+2. **Battery Settings**: Exclude your terminal app from battery optimization
+3. **Persistent Notification**: Some terminal apps can show a persistent notification to stay alive
+
+## Troubleshooting
+
+### Permission Denied
+If you get permission errors:
+```bash
+chmod +x wstunnel
+```
+
+### Network Issues
+- Ensure your Android device has network connectivity
+- Check if your carrier blocks WebSocket connections
+- Try using WSS (secure WebSocket) instead of WS
+
+### Process Killed
+If Android keeps killing the process:
+- Use `termux-wake-lock` in Termux
+- Disable battery optimization for the terminal app
+- Consider using a VPN app that supports custom protocols instead
+
+## Alternative: GUI Wrapper
+
+For users who prefer a graphical interface, you could:
+1. Use automation apps like Tasker or Automate to create a GUI wrapper
+2. Create shortcuts using terminal launcher apps
+3. Use SSH clients that support running commands on connect
+
+## Security Notes
+
+- Store your token securely, don't hardcode it in scripts
+- Use WSS (WebSocket Secure) when possible
+- Be aware that some networks may inspect WebSocket traffic
+- Consider using a VPN in addition to WStunnel for extra security
+
+## Limitations
+
+- No native Android GUI (command-line only)
+- Battery usage may be higher due to persistent connection
+- Some Android versions may aggressively kill background processes
+- Root access may be required for binding to privileged ports
+
+For more information, see the main [README](../README.md).


### PR DESCRIPTION
- Add Android OS target to GoReleaser configuration for ARM64 builds
- Create comprehensive Android usage documentation (docs/ANDROID.md)
- Add Android section to README.md linking to the new documentation
- Configure GoReleaser to exclude unsupported Android architectures (amd64, 386)

The Android documentation covers:
- Installation methods (pre-built binaries and source compilation)
- Termux setup and usage instructions
- Background operation and auto-start configuration
- Battery optimization recommendations
- Security considerations and troubleshooting tips

Enables Android users to run WStunnel as a client on their devices.

Closes #136