### PR TITLE
feat: add base path support for reverse proxy deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,11 @@ WStunnel is a WebSocket-based reverse HTTP/HTTPS tunneling solution that enables
 ## Configuration Options
 - **Max Requests Per Tunnel**: Use `-max-requests-per-tunnel N` to limit queued requests per tunnel (default: 20)
 - **Max Clients Per Token**: Use `-max-clients-per-token N` to limit concurrent clients per token (default: 0/unlimited)
+- **Base Path**: Use `-base-path /path` to run behind reverse proxies with path-based routing (e.g., `-base-path /wstunnel`)
 - When a tunnel reaches the max request limit, new requests return "too many requests in-flight, tunnel broken?"
 - When a token reaches the max client limit, new connections return HTTP 429 "Maximum number of clients reached"
 - Client counts are automatically decremented when clients disconnect
+- Base path configuration automatically prefixes all endpoints (/_tunnel, /_health_check, /_stats, /_token/) with the specified path
 
 ## CodeRabbit Review Settings
 The project uses CodeRabbit for automated code reviews (see `.coderabbit.yaml`). When writing code, ensure compliance with:

--- a/docs/PROXY_EXAMPLES.md
+++ b/docs/PROXY_EXAMPLES.md
@@ -1,0 +1,512 @@
+# Proxy Configuration Examples for WStunnel Base Path
+
+This document provides configuration examples for running WStunnel behind various reverse proxies using the `-base-path` option.
+
+## Overview
+
+When deploying WStunnel in containerized environments or behind reverse proxies, you often need to host it under a specific path prefix. The `-base-path` option allows WStunnel to work correctly in these scenarios by:
+
+1. Configuring all endpoints under the specified base path
+2. Automatically stripping the base path from incoming requests
+3. Ensuring proper routing for WebSocket upgrades and HTTP requests
+
+## Envoy Proxy
+
+### Basic Configuration
+
+```yaml
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/wstunnel/"
+                route:
+                  cluster: wstunnel_service
+                  prefix_rewrite: "/"
+              - match:
+                  prefix: "/wstunnel"
+                route:
+                  cluster: wstunnel_service
+                  prefix_rewrite: "/"
+          http_filters:
+          - name: envoy.filters.http.router
+          upgrade_configs:
+          - upgrade_type: websocket
+
+  clusters:
+  - name: wstunnel_service
+    connect_timeout: 30s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: wstunnel_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: wstunnel-server
+                port_value: 8080
+```
+
+### WStunnel Server Configuration
+
+```bash
+./wstunnel srv -port 8080 -base-path /wstunnel
+```
+
+### Usage Examples
+
+```bash
+# Health check
+curl http://proxy.example.com:8080/wstunnel/_health_check
+
+# Stats endpoint
+curl http://proxy.example.com:8080/wstunnel/_stats
+
+# WebSocket tunnel connection
+./wstunnel cli -tunnel ws://proxy.example.com:8080/wstunnel -server http://localhost -token 'your-token'
+
+# Token-based HTTP request
+curl 'http://proxy.example.com:8080/wstunnel/_token/your-token/api/endpoint'
+```
+
+## Istio Ingress Gateway
+
+### Gateway Configuration
+
+```yaml
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: wstunnel-gateway
+  namespace: wstunnel
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - tunnel.example.com
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: tunnel-tls-secret
+    hosts:
+    - tunnel.example.com
+```
+
+### VirtualService Configuration
+
+```yaml
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: wstunnel-vs
+  namespace: wstunnel
+spec:
+  hosts:
+  - tunnel.example.com
+  gateways:
+  - wstunnel-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /api/v1/wstunnel/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: wstunnel-service
+        port:
+          number: 8080
+  - match:
+    - uri:
+        exact: /api/v1/wstunnel
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: wstunnel-service
+        port:
+          number: 8080
+```
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wstunnel-server
+  namespace: wstunnel
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wstunnel-server
+  template:
+    metadata:
+      labels:
+        app: wstunnel-server
+    spec:
+      containers:
+      - name: wstunnel
+        image: wstunnel:latest
+        args:
+        - "srv"
+        - "-port"
+        - "8080"
+        - "-base-path"
+        - "/api/v1/wstunnel"
+        - "-max-requests-per-tunnel"
+        - "50"
+        - "-max-clients-per-token"
+        - "10"
+        ports:
+        - containerPort: 8080
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /api/v1/wstunnel/_health_check
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /api/v1/wstunnel/_health_check
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wstunnel-service
+  namespace: wstunnel
+spec:
+  selector:
+    app: wstunnel-server
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  type: ClusterIP
+```
+
+### Usage Examples
+
+```bash
+# Health check
+curl https://tunnel.example.com/api/v1/wstunnel/_health_check
+
+# WebSocket tunnel connection
+./wstunnel cli -tunnel wss://tunnel.example.com/api/v1/wstunnel -server http://localhost -token 'your-token'
+
+# Token-based HTTPS request
+curl 'https://tunnel.example.com/api/v1/wstunnel/_token/your-token/api/endpoint'
+```
+
+## Nginx
+
+### Configuration
+
+```nginx
+upstream wstunnel_backend {
+    server wstunnel-server:8080;
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name tunnel.example.com;
+
+    ssl_certificate /etc/ssl/certs/tunnel.crt;
+    ssl_certificate_key /etc/ssl/private/tunnel.key;
+
+    # WStunnel with base path
+    location /tunnel/ {
+        proxy_pass http://wstunnel_backend/;
+        
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        
+        # Standard proxy headers
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Disable buffering for real-time applications
+        proxy_buffering off;
+        proxy_read_timeout 86400;
+        proxy_send_timeout 86400;
+    }
+
+    # Exact match for base path without trailing slash
+    location = /tunnel {
+        proxy_pass http://wstunnel_backend/;
+        
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        proxy_buffering off;
+        proxy_read_timeout 86400;
+        proxy_send_timeout 86400;
+    }
+}
+```
+
+### WStunnel Server Configuration
+
+```bash
+./wstunnel srv -port 8080 -base-path /tunnel
+```
+
+### Docker Compose Example
+
+```yaml
+version: '3.8'
+
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./ssl:/etc/ssl
+    depends_on:
+      - wstunnel
+
+  wstunnel:
+    image: wstunnel:latest
+    command:
+      - "srv"
+      - "-port"
+      - "8080"
+      - "-base-path"
+      - "/tunnel"
+      - "-max-requests-per-tunnel"
+      - "30"
+    ports:
+      - "8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/tunnel/_health_check"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+## HAProxy
+
+### Configuration
+
+```haproxy
+global
+    daemon
+    maxconn 4096
+
+defaults
+    mode http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+frontend wstunnel_frontend
+    bind *:80
+    bind *:443 ssl crt /etc/ssl/certs/tunnel.pem
+
+    # Route requests with /ws-tunnel prefix to WStunnel
+    acl is_wstunnel path_beg /ws-tunnel
+    use_backend wstunnel_backend if is_wstunnel
+
+    # Default backend for other requests
+    default_backend default_backend
+
+backend wstunnel_backend
+    # Strip the /ws-tunnel prefix before forwarding
+    http-request replace-path /ws-tunnel(/.*) \1
+    http-request replace-path /ws-tunnel$ /
+    
+    # WebSocket support
+    option http-server-close
+    option forwardfor
+    
+    server wstunnel1 wstunnel-server:8080 check
+    server wstunnel2 wstunnel-server2:8080 check backup
+
+backend default_backend
+    server web1 web-server:80 check
+```
+
+### WStunnel Server Configuration
+
+```bash
+./wstunnel srv -port 8080 -base-path /ws-tunnel
+```
+
+## Apache HTTP Server
+
+### Configuration
+
+```apache
+<VirtualHost *:80>
+    ServerName tunnel.example.com
+    
+    # Enable modules
+    LoadModule proxy_module modules/mod_proxy.so
+    LoadModule proxy_http_module modules/mod_proxy_http.so
+    LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+    LoadModule rewrite_module modules/mod_rewrite.so
+
+    # Proxy WebSocket requests
+    ProxyPreserveHost On
+    ProxyRequests Off
+
+    # Handle WebSocket upgrade
+    RewriteEngine On
+    RewriteCond %{HTTP:Upgrade} websocket [NC]
+    RewriteCond %{HTTP:Connection} upgrade [NC]
+    RewriteRule ^/api/tunnel/(.*)$ ws://wstunnel-server:8080/$1 [P,L]
+
+    # Handle regular HTTP requests
+    ProxyPass /api/tunnel/ http://wstunnel-server:8080/
+    ProxyPassReverse /api/tunnel/ http://wstunnel-server:8080/
+    
+    # Handle exact match without trailing slash
+    ProxyPass /api/tunnel http://wstunnel-server:8080/
+    ProxyPassReverse /api/tunnel http://wstunnel-server:8080/
+</VirtualHost>
+```
+
+### WStunnel Server Configuration
+
+```bash
+./wstunnel srv -port 8080 -base-path /api/tunnel
+```
+
+## Kubernetes Ingress (nginx-ingress)
+
+### Ingress Configuration
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wstunnel-ingress
+  namespace: wstunnel
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/websocket-services: "wstunnel-service"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - tunnel.example.com
+    secretName: tunnel-tls
+  rules:
+  - host: tunnel.example.com
+    http:
+      paths:
+      - path: /v1/wstunnel(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: wstunnel-service
+            port:
+              number: 8080
+```
+
+### WStunnel Server Configuration
+
+```bash
+./wstunnel srv -port 8080 -base-path /v1/wstunnel
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **WebSocket connections fail**: Ensure your proxy supports WebSocket upgrades and has appropriate timeout settings.
+
+2. **Base path not stripped**: Verify that your proxy is correctly rewriting paths before forwarding to WStunnel.
+
+3. **Health checks fail**: Make sure health check paths include the base path (e.g., `/wstunnel/_health_check`).
+
+4. **SSL/TLS issues**: When using HTTPS, ensure proper certificate configuration and that the proxy forwards the correct protocol headers.
+
+### Debugging
+
+1. **Check WStunnel logs** for base path configuration:
+   ```
+   INFO Base path configured basePath=/your-path
+   ```
+
+2. **Test endpoints individually**:
+   ```bash
+   # Health check
+   curl -v http://proxy.example.com/your-path/_health_check
+   
+   # Stats
+   curl -v http://proxy.example.com/your-path/_stats
+   ```
+
+3. **Verify WebSocket upgrade headers**:
+   ```bash
+   curl -H "Connection: Upgrade" -H "Upgrade: websocket" \
+        -v ws://proxy.example.com/your-path/_tunnel
+   ```
+
+4. **Check proxy access logs** for correct path rewriting.
+
+### Performance Considerations
+
+- Set appropriate timeout values for long-lived WebSocket connections
+- Use connection pooling when available
+- Configure proper buffering settings for real-time applications
+- Monitor resource usage and scale accordingly
+- Consider using multiple WStunnel instances behind a load balancer for high availability
+
+## Security Considerations
+
+- Always use HTTPS/WSS in production environments
+- Implement proper authentication and authorization at the proxy level
+- Use secure headers (HSTS, CSP, etc.) when terminating SSL at the proxy
+- Regularly update proxy software and security configurations
+- Monitor and log access for security analysis
+- Consider rate limiting and DDoS protection at the proxy level

--- a/tunnel/basepath_test.go
+++ b/tunnel/basepath_test.go
@@ -1,0 +1,666 @@
+package tunnel
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+func TestNormalizeBasePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			expected: "",
+		},
+		{
+			name:     "root path",
+			input:    "/",
+			expected: "/",
+		},
+		{
+			name:     "simple path",
+			input:    "/wstunnel",
+			expected: "/wstunnel",
+		},
+		{
+			name:     "path without leading slash",
+			input:    "wstunnel",
+			expected: "/wstunnel",
+		},
+		{
+			name:     "path with trailing slash",
+			input:    "/wstunnel/",
+			expected: "/wstunnel",
+		},
+		{
+			name:     "nested path",
+			input:    "/api/v1/tunnel",
+			expected: "/api/v1/tunnel",
+		},
+		{
+			name:     "nested path with trailing slash",
+			input:    "/api/v1/tunnel/",
+			expected: "/api/v1/tunnel",
+		},
+		{
+			name:     "path with whitespace",
+			input:    "  /wstunnel  ",
+			expected: "/wstunnel",
+		},
+		{
+			name:     "path without leading slash and with trailing slash",
+			input:    "wstunnel/",
+			expected: "/wstunnel",
+		},
+		{
+			name:     "root path with extra slashes",
+			input:    "///",
+			expected: "/",
+		},
+		{
+			name:     "path traversal attempt with ..",
+			input:    "/wstunnel/../admin",
+			expected: "",
+		},
+		{
+			name:     "path traversal at start",
+			input:    "../wstunnel",
+			expected: "",
+		},
+		{
+			name:     "path traversal in middle",
+			input:    "/api/../tunnel",
+			expected: "",
+		},
+		{
+			name:     "encoded path traversal attempt",
+			input:    "/wstunnel/%2e%2e/admin",
+			expected: "/wstunnel/%2e%2e/admin", // Not decoded, so allowed
+		},
+		{
+			name:     "path exceeding max length",
+			input:    "/" + strings.Repeat("a", 300),
+			expected: "",
+		},
+		{
+			name:     "path with null byte",
+			input:    "/wstunnel\x00/test",
+			expected: "",
+		},
+		{
+			name:     "path with control characters",
+			input:    "/wstunnel\x01\x02",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeBasePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeBasePath(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldStripBasePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestPath string
+		basePath    string
+		expected    bool
+	}{
+		{
+			name:        "exact match",
+			requestPath: "/wstunnel",
+			basePath:    "/wstunnel",
+			expected:    true,
+		},
+		{
+			name:        "base path with trailing slash in request",
+			requestPath: "/wstunnel/",
+			basePath:    "/wstunnel",
+			expected:    true,
+		},
+		{
+			name:        "base path with sub path",
+			requestPath: "/wstunnel/_tunnel",
+			basePath:    "/wstunnel",
+			expected:    true,
+		},
+		{
+			name:        "partial match (should not strip)",
+			requestPath: "/wstunnel2/_tunnel",
+			basePath:    "/wstunnel",
+			expected:    false,
+		},
+		{
+			name:        "no match",
+			requestPath: "/other/_tunnel",
+			basePath:    "/wstunnel",
+			expected:    false,
+		},
+		{
+			name:        "nested base path exact match",
+			requestPath: "/api/v1",
+			basePath:    "/api/v1",
+			expected:    true,
+		},
+		{
+			name:        "nested base path with sub path",
+			requestPath: "/api/v1/_tunnel",
+			basePath:    "/api/v1",
+			expected:    true,
+		},
+		{
+			name:        "nested base path partial match (should not strip)",
+			requestPath: "/api/v1extra/_tunnel",
+			basePath:    "/api/v1",
+			expected:    false,
+		},
+		{
+			name:        "root base path (should not strip)",
+			requestPath: "/",
+			basePath:    "/",
+			expected:    false,
+		},
+		{
+			name:        "root base path with sub path (should not strip)",
+			requestPath: "/_tunnel",
+			basePath:    "/",
+			expected:    false,
+		},
+		{
+			name:        "empty base path",
+			requestPath: "/_tunnel",
+			basePath:    "",
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldStripBasePath(tt.requestPath, tt.basePath)
+			if result != tt.expected {
+				t.Errorf("shouldStripBasePath(%q, %q) = %v, expected %v", tt.requestPath, tt.basePath, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		basePath  string
+		routePath string
+		expected  string
+	}{
+		{
+			name:      "empty base path",
+			basePath:  "",
+			routePath: "/",
+			expected:  "/",
+		},
+		{
+			name:      "empty base path with route",
+			basePath:  "",
+			routePath: "/_tunnel",
+			expected:  "/_tunnel",
+		},
+		{
+			name:      "base path with root route",
+			basePath:  "/wstunnel",
+			routePath: "/",
+			expected:  "/wstunnel/",
+		},
+		{
+			name:      "base path with specific route",
+			basePath:  "/wstunnel",
+			routePath: "/_tunnel",
+			expected:  "/wstunnel/_tunnel",
+		},
+		{
+			name:      "base path with token route",
+			basePath:  "/wstunnel",
+			routePath: "/_token/",
+			expected:  "/wstunnel/_token/",
+		},
+		{
+			name:      "nested base path",
+			basePath:  "/api/v1",
+			routePath: "/_health_check",
+			expected:  "/api/v1/_health_check",
+		},
+		{
+			name:      "nested base path with stats",
+			basePath:  "/api/v1",
+			routePath: "/_stats",
+			expected:  "/api/v1/_stats",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildPath(tt.basePath, tt.routePath)
+			if result != tt.expected {
+				t.Errorf("buildPath(%q, %q) = %q, expected %q", tt.basePath, tt.routePath, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewWSTunnelServer_BasePath_Configuration(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		expectedPath string
+		expectLog    string
+	}{
+		{
+			name:         "default empty base path",
+			args:         []string{"-port", "0"},
+			expectedPath: "",
+			expectLog:    "",
+		},
+		{
+			name:         "simple base path",
+			args:         []string{"-port", "0", "-base-path", "/wstunnel"},
+			expectedPath: "/wstunnel",
+			expectLog:    "Base path configured",
+		},
+		{
+			name:         "base path without leading slash",
+			args:         []string{"-port", "0", "-base-path", "wstunnel"},
+			expectedPath: "/wstunnel",
+			expectLog:    "Base path configured",
+		},
+		{
+			name:         "base path with trailing slash",
+			args:         []string{"-port", "0", "-base-path", "/wstunnel/"},
+			expectedPath: "/wstunnel",
+			expectLog:    "Base path configured",
+		},
+		{
+			name:         "nested base path",
+			args:         []string{"-port", "0", "-base-path", "/api/v1/tunnel"},
+			expectedPath: "/api/v1/tunnel",
+			expectLog:    "Base path configured",
+		},
+		{
+			name:         "base path with whitespace",
+			args:         []string{"-port", "0", "-base-path", "  /wstunnel  "},
+			expectedPath: "/wstunnel",
+			expectLog:    "Base path configured",
+		},
+		{
+			name:         "empty base path string",
+			args:         []string{"-port", "0", "-base-path", ""},
+			expectedPath: "",
+			expectLog:    "",
+		},
+		{
+			name:         "whitespace only base path",
+			args:         []string{"-port", "0", "-base-path", "   "},
+			expectedPath: "",
+			expectLog:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture log output
+			var logOutput bytes.Buffer
+			log15.Root().SetHandler(log15.StreamHandler(&logOutput, log15.LogfmtFormat()))
+
+			server := NewWSTunnelServer(tt.args)
+			if server == nil {
+				t.Fatal("Expected server to be created")
+			}
+
+			// Check the base path was set correctly
+			if server.BasePath != tt.expectedPath {
+				t.Errorf("Expected BasePath to be %q, got %q", tt.expectedPath, server.BasePath)
+			}
+
+			// Check log output
+			logStr := logOutput.String()
+			if tt.expectLog != "" {
+				if !strings.Contains(logStr, tt.expectLog) {
+					t.Errorf("Expected log to contain %q, but log was: %s", tt.expectLog, logStr)
+				}
+				if !strings.Contains(logStr, fmt.Sprintf("basePath=%s", tt.expectedPath)) {
+					t.Errorf("Expected log to contain basePath=%s, but log was: %s", tt.expectedPath, logStr)
+				}
+			} else {
+				if strings.Contains(logStr, "Base path configured") {
+					t.Errorf("Expected no base path log, but found: %s", logStr)
+				}
+			}
+		})
+	}
+}
+
+func TestWSTunnelServer_URLRewriting(t *testing.T) {
+	tests := []struct {
+		name          string
+		basePath      string
+		requestPath   string
+		expectedPath  string
+		shouldRewrite bool
+	}{
+		{
+			name:          "no base path configured",
+			basePath:      "",
+			requestPath:   "/_tunnel",
+			expectedPath:  "/_tunnel",
+			shouldRewrite: false,
+		},
+		{
+			name:          "base path matches - tunnel endpoint",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel/_tunnel",
+			expectedPath:  "/_tunnel",
+			shouldRewrite: true,
+		},
+		{
+			name:          "base path matches - health check",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel/_health_check",
+			expectedPath:  "/_health_check",
+			shouldRewrite: true,
+		},
+		{
+			name:          "base path matches - stats",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel/_stats",
+			expectedPath:  "/_stats",
+			shouldRewrite: true,
+		},
+		{
+			name:          "base path matches - token prefix",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel/_token/test123/some/path",
+			expectedPath:  "/_token/test123/some/path",
+			shouldRewrite: true,
+		},
+		{
+			name:          "base path matches - root becomes root",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel",
+			expectedPath:  "/",
+			shouldRewrite: true,
+		},
+		{
+			name:          "base path matches - root with slash",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel/",
+			expectedPath:  "/",
+			shouldRewrite: true,
+		},
+		{
+			name:          "base path doesn't match",
+			basePath:      "/wstunnel",
+			requestPath:   "/other/_tunnel",
+			expectedPath:  "/other/_tunnel",
+			shouldRewrite: false,
+		},
+		{
+			name:          "nested base path",
+			basePath:      "/api/v1",
+			requestPath:   "/api/v1/_tunnel",
+			expectedPath:  "/_tunnel",
+			shouldRewrite: true,
+		},
+		{
+			name:          "partial base path match (should not rewrite)",
+			basePath:      "/wstunnel",
+			requestPath:   "/wstunnel2/_tunnel",
+			expectedPath:  "/wstunnel2/_tunnel",
+			shouldRewrite: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test server
+			server := &WSTunnelServer{
+				BasePath: tt.basePath,
+				Log:      log15.New(),
+			}
+			server.Log.SetHandler(log15.DiscardHandler())
+
+			// Create a test handler that records the rewritten URL
+			var rewrittenPath string
+			testHandler := func(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
+				rewrittenPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}
+
+			// Create the wrapper function (simulating the wrap function from Start)
+			wrap := func(h func(t *WSTunnelServer, w http.ResponseWriter, r *http.Request)) func(http.ResponseWriter, *http.Request) {
+				return func(w http.ResponseWriter, r *http.Request) {
+					// Strip base path from request URL if configured
+					if server.BasePath != "" && shouldStripBasePath(r.URL.Path, server.BasePath) {
+						// Create a new URL with the base path stripped
+						newPath := strings.TrimPrefix(r.URL.Path, server.BasePath)
+						if newPath == "" {
+							newPath = "/"
+						}
+						r.URL.Path = newPath
+					}
+					h(server, w, r)
+				}
+			}
+
+			// Create a test request
+			req := httptest.NewRequest("GET", tt.requestPath, nil)
+			w := httptest.NewRecorder()
+
+			// Call the wrapped handler
+			wrappedHandler := wrap(testHandler)
+			wrappedHandler(w, req)
+
+			// Check that the path was rewritten correctly
+			if rewrittenPath != tt.expectedPath {
+				t.Errorf("Expected rewritten path to be %q, got %q", tt.expectedPath, rewrittenPath)
+			}
+
+			// Verify the original request URL is modified as expected
+			if tt.shouldRewrite {
+				if req.URL.Path != tt.expectedPath {
+					t.Errorf("Expected request URL path to be modified to %q, got %q", tt.expectedPath, req.URL.Path)
+				}
+			}
+		})
+	}
+}
+
+func TestWSTunnelServer_RouteRegistration_BasePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+		routes   map[string]string // route -> expected registered path
+	}{
+		{
+			name:     "no base path",
+			basePath: "",
+			routes: map[string]string{
+				"/":              "/",
+				"/_token/":       "/_token/",
+				"/_tunnel":       "/_tunnel",
+				"/_health_check": "/_health_check",
+				"/_stats":        "/_stats",
+			},
+		},
+		{
+			name:     "simple base path",
+			basePath: "/wstunnel",
+			routes: map[string]string{
+				"/":              "/wstunnel/",
+				"/_token/":       "/wstunnel/_token/",
+				"/_tunnel":       "/wstunnel/_tunnel",
+				"/_health_check": "/wstunnel/_health_check",
+				"/_stats":        "/wstunnel/_stats",
+			},
+		},
+		{
+			name:     "nested base path",
+			basePath: "/api/v1",
+			routes: map[string]string{
+				"/":              "/api/v1/",
+				"/_token/":       "/api/v1/_token/",
+				"/_tunnel":       "/api/v1/_tunnel",
+				"/_health_check": "/api/v1/_health_check",
+				"/_stats":        "/api/v1/_stats",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test buildPath function for each route
+			for routePath, expectedPath := range tt.routes {
+				result := buildPath(tt.basePath, routePath)
+				if result != expectedPath {
+					t.Errorf("buildPath(%q, %q) = %q, expected %q", tt.basePath, routePath, result, expectedPath)
+				}
+			}
+		})
+	}
+}
+
+func TestWSTunnelServer_Integration_BasePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		basePath    string
+		requestPath string
+		expectCode  int
+	}{
+		{
+			name:        "health check with base path",
+			basePath:    "/wstunnel",
+			requestPath: "/wstunnel/_health_check",
+			expectCode:  200,
+		},
+		{
+			name:        "request without base path prefix should 404",
+			basePath:    "/wstunnel",
+			requestPath: "/_health_check",
+			expectCode:  404,
+		},
+		{
+			name:        "incorrect base path prefix should 404",
+			basePath:    "/wstunnel",
+			requestPath: "/wrong/_health_check",
+			expectCode:  404,
+		},
+		{
+			name:        "health check without base path",
+			basePath:    "",
+			requestPath: "/_health_check",
+			expectCode:  200,
+		},
+		{
+			name:        "stats with base path",
+			basePath:    "/wstunnel",
+			requestPath: "/wstunnel/_stats",
+			expectCode:  200,
+		},
+		{
+			name:        "stats without base path",
+			basePath:    "",
+			requestPath: "/_stats",
+			expectCode:  200,
+		},
+		{
+			name:        "tunnel endpoint with base path",
+			basePath:    "/wstunnel",
+			requestPath: "/wstunnel/_tunnel",
+			expectCode:  400, // GET to tunnel without proper WebSocket upgrade
+		},
+		{
+			name:        "nested base path health check",
+			basePath:    "/api/v1",
+			requestPath: "/api/v1/_health_check",
+			expectCode:  200,
+		},
+		{
+			name:        "base path with special valid characters",
+			basePath:    "/api-v1.2_test",
+			requestPath: "/api-v1.2_test/_health_check",
+			expectCode:  200,
+		},
+		{
+			name:        "base path with URL encoded characters",
+			basePath:    "/api%20v1",
+			requestPath: "/api%20v1/_health_check",
+			expectCode:  200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create server with specific base path
+			args := []string{"-port", "0"}
+			if tt.basePath != "" {
+				args = append(args, "-base-path", tt.basePath)
+			}
+
+			server := NewWSTunnelServer(args)
+			if server == nil {
+				t.Fatal("Expected server to be created")
+			}
+			server.Log.SetHandler(log15.DiscardHandler())
+
+			// Start the server
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = listener.Close() }()
+
+			go server.Start(listener)
+			defer server.Stop()
+
+			// Create HTTP client and make request
+			client := &http.Client{}
+			url := fmt.Sprintf("http://%s%s", listener.Addr().String(), tt.requestPath)
+
+			req, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("Failed to close response body: %v", err)
+				}
+			}()
+
+			if resp.StatusCode != tt.expectCode {
+				t.Errorf("Expected status code %d, got %d", tt.expectCode, resp.StatusCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add -base-path configuration option to enable WStunnel server deployment behind reverse proxies (Envoy, Istio, nginx) with path-based routing.

## Summary

* Add -base-path command-line flag to configure base path prefix
* Implement automatic path normalization (leading/trailing slashes)
* Update HTTP route registration to use base path prefixes
* Add URL rewriting middleware to strip base path from requests
* Preserve existing functionality when no base path is configured

## Features

* **Base Path Configuration**: New -base-path flag for server deployment
* **Path Normalization**: Automatic handling of leading/trailing slashes
* **Route Prefixing**: All endpoints (/_tunnel, /_health_check, /_stats, /_token/) support base paths
* **URL Rewriting**: Transparent base path removal before request processing
* **Backward Compatibility**: No impact on existing deployments

## Implementation Details

* Added BasePath field to WSTunnelServer struct
* Created normalizeBasePath() helper for path validation
* Implemented shouldStripBasePath() for proper URL matching
* Added buildPath() utility for route construction
* Enhanced HTTP handler wrapper for automatic path stripping

## Testing

* Comprehensive unit tests for path normalization and URL rewriting
* Integration tests with real HTTP servers and various base path configurations
* Edge case testing for empty paths, root paths, and special characters
* All existing tests continue to pass

## Documentation

* Updated README.md with base path configuration examples
* Enhanced CLAUDE.md with operational guidance
* Created comprehensive proxy configuration examples (Envoy, Istio, nginx, HAProxy)
* Added Kubernetes deployment examples and troubleshooting guide

## Use Cases

This enables WStunnel deployment in modern containerized environments:

* Kubernetes ingress controllers with path-based routing
* Istio service mesh with VirtualService path matching
* Envoy proxy configurations with prefix routing
* nginx reverse proxy setups with location blocks
* API gateway deployments with versioned paths

## Example Usage

```bash
# Deploy behind reverse proxy at /wstunnel path
./wstunnel srv -port 8080 -base-path /wstunnel

# Access endpoints with base path
curl http://proxy.example.com/wstunnel/_health_check
curl http://proxy.example.com/wstunnel/_stats
```

Resolves #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a base URL path prefix for all server endpoints, enabling operation behind reverse proxies with path-based routing.
  - Enhanced server routing to correctly handle requests under the configured base path with improved error handling and stability.
- **Documentation**
  - Updated documentation to explain the new base path option, including configuration instructions and usage examples.
  - Added a comprehensive guide with proxy configuration examples, troubleshooting tips, and security considerations for using the base path feature.
- **Tests**
  - Introduced extensive tests to verify correct handling and normalization of base paths in server routing and request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->