### PR TITLE
feat(admin): add tunnel control API for force disconnect and token bl…

### DIFF
--- a/tunnel/admin_control_test.go
+++ b/tunnel/admin_control_test.go
@@ -1,0 +1,740 @@
+// Copyright (c) 2014 RightScale, Inc. - see LICENSE
+
+package tunnel
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- Unit tests for remoteServer connection tracking ---
+
+func TestRegisterAndDeregisterConnection(t *testing.T) {
+	rs := &remoteServer{
+		connCloseChans: make([]chan struct{}, 0),
+	}
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+
+	deregister1 := rs.RegisterConnection(ch1)
+	deregister2 := rs.RegisterConnection(ch2)
+
+	rs.connCloseMutex.Lock()
+	if len(rs.connCloseChans) != 2 {
+		t.Fatalf("expected 2 registered connections, got %d", len(rs.connCloseChans))
+	}
+	rs.connCloseMutex.Unlock()
+
+	// Deregister first connection
+	deregister1()
+
+	rs.connCloseMutex.Lock()
+	if len(rs.connCloseChans) != 1 {
+		t.Fatalf("expected 1 registered connection after deregister, got %d", len(rs.connCloseChans))
+	}
+	if rs.connCloseChans[0] != ch2 {
+		t.Fatal("expected remaining channel to be ch2")
+	}
+	rs.connCloseMutex.Unlock()
+
+	// Deregister second connection
+	deregister2()
+
+	rs.connCloseMutex.Lock()
+	if len(rs.connCloseChans) != 0 {
+		t.Fatalf("expected 0 registered connections after both deregister, got %d", len(rs.connCloseChans))
+	}
+	rs.connCloseMutex.Unlock()
+}
+
+func TestCloseAllConnections(t *testing.T) {
+	rs := &remoteServer{
+		connCloseChans: make([]chan struct{}, 0),
+	}
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	ch3 := make(chan struct{})
+
+	rs.RegisterConnection(ch1)
+	rs.RegisterConnection(ch2)
+	rs.RegisterConnection(ch3)
+
+	count := rs.CloseAllConnections()
+
+	if count != 3 {
+		t.Fatalf("expected 3 disconnected, got %d", count)
+	}
+
+	// Verify all channels are closed
+	for i, ch := range []chan struct{}{ch1, ch2, ch3} {
+		select {
+		case <-ch:
+			// good, channel is closed
+		default:
+			t.Fatalf("channel %d was not closed", i)
+		}
+	}
+
+	// Verify internal slice is cleared
+	rs.connCloseMutex.Lock()
+	if len(rs.connCloseChans) != 0 {
+		t.Fatalf("expected connCloseChans to be empty, got %d", len(rs.connCloseChans))
+	}
+	rs.connCloseMutex.Unlock()
+}
+
+func TestCloseAllConnectionsEmpty(t *testing.T) {
+	rs := &remoteServer{
+		connCloseChans: make([]chan struct{}, 0),
+	}
+
+	count := rs.CloseAllConnections()
+	if count != 0 {
+		t.Fatalf("expected 0 disconnected from empty server, got %d", count)
+	}
+}
+
+func TestCloseAllConnectionsIdempotent(t *testing.T) {
+	rs := &remoteServer{
+		connCloseChans: make([]chan struct{}, 0),
+	}
+
+	ch := make(chan struct{})
+	rs.RegisterConnection(ch)
+
+	// Close once
+	count1 := rs.CloseAllConnections()
+	if count1 != 1 {
+		t.Fatalf("expected 1, got %d", count1)
+	}
+
+	// Close again should return 0
+	count2 := rs.CloseAllConnections()
+	if count2 != 0 {
+		t.Fatalf("expected 0 on second call, got %d", count2)
+	}
+}
+
+func TestCloseAllConnectionsConcurrent(t *testing.T) {
+	rs := &remoteServer{
+		connCloseChans: make([]chan struct{}, 0),
+	}
+
+	const n = 10
+	channels := make([]chan struct{}, n)
+	for i := range channels {
+		channels[i] = make(chan struct{})
+		rs.RegisterConnection(channels[i])
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		rs.CloseAllConnections()
+	}()
+	go func() {
+		defer wg.Done()
+		rs.CloseAllConnections()
+	}()
+	wg.Wait()
+
+	// All channels should be closed regardless
+	for i, ch := range channels {
+		select {
+		case <-ch:
+		default:
+			t.Fatalf("channel %d was not closed", i)
+		}
+	}
+}
+
+// --- Unit tests for WSTunnelServer token blocking ---
+
+func TestBlockUnblockToken(t *testing.T) {
+	server := &WSTunnelServer{
+		blockedTokens: make(map[token]time.Time),
+	}
+
+	tok := token("test-token-1234567890")
+
+	if server.IsTokenBlocked(tok) {
+		t.Fatal("token should not be blocked initially")
+	}
+
+	server.BlockToken(tok)
+
+	if !server.IsTokenBlocked(tok) {
+		t.Fatal("token should be blocked after BlockToken")
+	}
+
+	existed := server.UnblockToken(tok)
+	if !existed {
+		t.Fatal("UnblockToken should return true for previously blocked token")
+	}
+
+	if server.IsTokenBlocked(tok) {
+		t.Fatal("token should not be blocked after UnblockToken")
+	}
+}
+
+func TestUnblockNonexistentToken(t *testing.T) {
+	server := &WSTunnelServer{
+		blockedTokens: make(map[token]time.Time),
+	}
+
+	existed := server.UnblockToken(token("never-blocked-token"))
+	if existed {
+		t.Fatal("UnblockToken should return false for never-blocked token")
+	}
+}
+
+func TestGetBlockedTokens(t *testing.T) {
+	server := &WSTunnelServer{
+		blockedTokens: make(map[token]time.Time),
+	}
+
+	tok1 := token("test-token-aaaa1234")
+	tok2 := token("test-token-bbbb5678")
+
+	server.BlockToken(tok1)
+	server.BlockToken(tok2)
+
+	blocked := server.GetBlockedTokens()
+
+	if len(blocked) != 2 {
+		t.Fatalf("expected 2 blocked tokens, got %d", len(blocked))
+	}
+
+	if _, ok := blocked[tok1]; !ok {
+		t.Fatal("tok1 should be in blocked list")
+	}
+	if _, ok := blocked[tok2]; !ok {
+		t.Fatal("tok2 should be in blocked list")
+	}
+
+	// Verify it's a copy by modifying it
+	delete(blocked, tok1)
+	if !server.IsTokenBlocked(tok1) {
+		t.Fatal("modifying returned map should not affect server state")
+	}
+}
+
+func TestIsTokenBlocked(t *testing.T) {
+	server := &WSTunnelServer{
+		blockedTokens: make(map[token]time.Time),
+	}
+
+	if server.IsTokenBlocked(token("unknown-token-12345")) {
+		t.Fatal("unknown token should not be blocked")
+	}
+
+	tok := token("blocked-token-123456")
+	server.BlockToken(tok)
+
+	if !server.IsTokenBlocked(tok) {
+		t.Fatal("blocked token should report as blocked")
+	}
+}
+
+func TestDisconnectToken(t *testing.T) {
+	server := &WSTunnelServer{
+		serverRegistry:      make(map[token]*remoteServer),
+		serverRegistryMutex: sync.Mutex{},
+		blockedTokens:       make(map[token]time.Time),
+	}
+
+	tok := token("disconnect-test-token")
+
+	// Disconnect non-existent token should return 0
+	count := server.DisconnectToken(tok)
+	if count != 0 {
+		t.Fatalf("expected 0 for non-existent token, got %d", count)
+	}
+
+	// Create a remote server with connections
+	rs := &remoteServer{
+		token:          tok,
+		connCloseChans: make([]chan struct{}, 0),
+	}
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	rs.RegisterConnection(ch1)
+	rs.RegisterConnection(ch2)
+
+	server.serverRegistryMutex.Lock()
+	server.serverRegistry[tok] = rs
+	server.serverRegistryMutex.Unlock()
+
+	count = server.DisconnectToken(tok)
+	if count != 2 {
+		t.Fatalf("expected 2 disconnected, got %d", count)
+	}
+}
+
+// --- Handler tests ---
+
+func TestHandleTunnelDisconnect_Success(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	tok := token("test-disconnect-token")
+	rs := &remoteServer{
+		token:          tok,
+		connCloseChans: make([]chan struct{}, 0),
+	}
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	rs.RegisterConnection(ch1)
+	rs.RegisterConnection(ch2)
+
+	adminService.server.serverRegistry[tok] = rs
+
+	req := httptest.NewRequest("POST", "/admin/tunnels/test-disconnect-token/disconnect", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTunnelDisconnect(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp DisconnectResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Disconnected != 2 {
+		t.Fatalf("expected 2 disconnected, got %d", resp.Disconnected)
+	}
+
+	if resp.Message != "disconnected 2 connection(s)" {
+		t.Fatalf("unexpected message: %s", resp.Message)
+	}
+}
+
+func TestHandleTunnelDisconnect_NotFound(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/admin/tunnels/nonexistent-token-x/disconnect", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTunnelDisconnect(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", result.StatusCode)
+	}
+
+	var resp DisconnectResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Disconnected != 0 {
+		t.Fatalf("expected 0 disconnected, got %d", resp.Disconnected)
+	}
+}
+
+func TestHandleTunnelDisconnect_MethodNotAllowed(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/admin/tunnels/some-token-here123/disconnect", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTunnelDisconnect(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", result.StatusCode)
+	}
+}
+
+func TestHandleTunnelDisconnect_InvalidPath(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/admin/tunnels/", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTunnelDisconnect(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", result.StatusCode)
+	}
+}
+
+func TestHandleTokenBlock_Block(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	tok := token("block-test-token-1234")
+
+	req := httptest.NewRequest("POST", "/admin/tokens/block-test-token-1234/block", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTokenBlock(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp BlockResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp.Blocked {
+		t.Fatal("expected blocked to be true")
+	}
+
+	// Verify token is actually blocked
+	if !adminService.server.IsTokenBlocked(tok) {
+		t.Fatal("token should be blocked on server")
+	}
+}
+
+func TestHandleTokenBlock_BlockWithDisconnect(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	tok := token("block-disconnect-token")
+	rs := &remoteServer{
+		token:          tok,
+		connCloseChans: make([]chan struct{}, 0),
+	}
+	ch := make(chan struct{})
+	rs.RegisterConnection(ch)
+	adminService.server.serverRegistry[tok] = rs
+
+	req := httptest.NewRequest("POST", "/admin/tokens/block-disconnect-token/block?disconnect=true", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTokenBlock(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp BlockResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp.Blocked {
+		t.Fatal("expected blocked to be true")
+	}
+
+	if resp.Disconnected != 1 {
+		t.Fatalf("expected 1 disconnected, got %d", resp.Disconnected)
+	}
+
+	// Verify channel was closed
+	select {
+	case <-ch:
+		// good
+	default:
+		t.Fatal("connection channel should be closed")
+	}
+}
+
+func TestHandleTokenBlock_Unblock(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	tok := token("unblock-test-token-12")
+
+	// Block first
+	adminService.server.BlockToken(tok)
+
+	req := httptest.NewRequest("DELETE", "/admin/tokens/unblock-test-token-12/block", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTokenBlock(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp BlockResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Blocked {
+		t.Fatal("expected blocked to be false after unblock")
+	}
+
+	// Verify token is actually unblocked
+	if adminService.server.IsTokenBlocked(tok) {
+		t.Fatal("token should be unblocked on server")
+	}
+}
+
+func TestHandleTokenBlock_MethodNotAllowed(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("PUT", "/admin/tokens/some-test-token-xyz/block", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTokenBlock(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", result.StatusCode)
+	}
+}
+
+func TestHandleBlockedTokens_Empty(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/admin/tokens/blocked", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleBlockedTokens(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp BlockedTokensResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Count != 0 {
+		t.Fatalf("expected 0 blocked tokens, got %d", resp.Count)
+	}
+
+	if len(resp.BlockedTokens) != 0 {
+		t.Fatalf("expected empty blocked_tokens list, got %d", len(resp.BlockedTokens))
+	}
+}
+
+func TestHandleBlockedTokens_WithTokens(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	adminService.server.BlockToken(token("blocked-token-aaaaaa"))
+	adminService.server.BlockToken(token("blocked-token-bbbbbb"))
+
+	req := httptest.NewRequest("GET", "/admin/tokens/blocked", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleBlockedTokens(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp BlockedTokensResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Count != 2 {
+		t.Fatalf("expected 2 blocked tokens, got %d", resp.Count)
+	}
+
+	if len(resp.BlockedTokens) != 2 {
+		t.Fatalf("expected 2 entries in blocked_tokens, got %d", len(resp.BlockedTokens))
+	}
+
+	// Verify tokens are truncated (cutToken format: first 8 chars + "...")
+	for _, bt := range resp.BlockedTokens {
+		if len(bt.Token) > 11 {
+			t.Fatalf("expected truncated token, got %q", bt.Token)
+		}
+	}
+}
+
+func TestHandleBlockedTokens_MethodNotAllowed(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/admin/tokens/blocked", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleBlockedTokens(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", result.StatusCode)
+	}
+}
+
+// --- Lifecycle test ---
+
+func TestBlockDisconnectLifecycle(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	tok := token("lifecycle-test-token1")
+
+	// 1. Token should not be blocked initially
+	if adminService.server.IsTokenBlocked(tok) {
+		t.Fatal("token should not be blocked initially")
+	}
+
+	// 2. Block the token
+	blockReq := httptest.NewRequest("POST", "/admin/tokens/lifecycle-test-token1/block", nil)
+	blockW := httptest.NewRecorder()
+	adminService.HandleTokenBlock(blockW, blockReq)
+
+	blockResult := blockW.Result()
+	defer func() { _ = blockResult.Body.Close() }()
+
+	if blockResult.StatusCode != http.StatusOK {
+		t.Fatalf("block: expected 200, got %d", blockResult.StatusCode)
+	}
+
+	// 3. Verify token appears in blocked list
+	listReq := httptest.NewRequest("GET", "/admin/tokens/blocked", nil)
+	listW := httptest.NewRecorder()
+	adminService.HandleBlockedTokens(listW, listReq)
+
+	listResult := listW.Result()
+	defer func() { _ = listResult.Body.Close() }()
+
+	var listResp BlockedTokensResponse
+	if err := json.NewDecoder(listResult.Body).Decode(&listResp); err != nil {
+		t.Fatal(err)
+	}
+
+	if listResp.Count != 1 {
+		t.Fatalf("expected 1 blocked token, got %d", listResp.Count)
+	}
+
+	// 4. Unblock the token
+	unblockReq := httptest.NewRequest("DELETE", "/admin/tokens/lifecycle-test-token1/block", nil)
+	unblockW := httptest.NewRecorder()
+	adminService.HandleTokenBlock(unblockW, unblockReq)
+
+	unblockResult := unblockW.Result()
+	defer func() { _ = unblockResult.Body.Close() }()
+
+	if unblockResult.StatusCode != http.StatusOK {
+		t.Fatalf("unblock: expected 200, got %d", unblockResult.StatusCode)
+	}
+
+	// 5. Verify token no longer in blocked list
+	listReq2 := httptest.NewRequest("GET", "/admin/tokens/blocked", nil)
+	listW2 := httptest.NewRecorder()
+	adminService.HandleBlockedTokens(listW2, listReq2)
+
+	listResult2 := listW2.Result()
+	defer func() { _ = listResult2.Body.Close() }()
+
+	var listResp2 BlockedTokensResponse
+	if err := json.NewDecoder(listResult2.Body).Decode(&listResp2); err != nil {
+		t.Fatal(err)
+	}
+
+	if listResp2.Count != 0 {
+		t.Fatalf("expected 0 blocked tokens after unblock, got %d", listResp2.Count)
+	}
+
+	// 6. Verify token is no longer blocked
+	if adminService.server.IsTokenBlocked(tok) {
+		t.Fatal("token should not be blocked after unblock")
+	}
+}
+
+func TestHandleTunnelDisconnect_WithBasePath(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	adminService.server.BasePath = "/wstunnel"
+
+	tok := token("basepath-test-token12")
+	rs := &remoteServer{
+		token:          tok,
+		connCloseChans: make([]chan struct{}, 0),
+	}
+	ch := make(chan struct{})
+	rs.RegisterConnection(ch)
+	adminService.server.serverRegistry[tok] = rs
+
+	req := httptest.NewRequest("POST", "/wstunnel/admin/tunnels/basepath-test-token12/disconnect", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTunnelDisconnect(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	var resp DisconnectResponse
+	if err := json.NewDecoder(result.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Disconnected != 1 {
+		t.Fatalf("expected 1 disconnected with base path, got %d", resp.Disconnected)
+	}
+}
+
+func TestHandleTokenBlock_WithBasePath(t *testing.T) {
+	adminService, cleanup := setupTestAdminService(t)
+	defer cleanup()
+
+	adminService.server.BasePath = "/wstunnel"
+
+	req := httptest.NewRequest("POST", "/wstunnel/admin/tokens/basepath-block-token1/block", nil)
+	w := httptest.NewRecorder()
+
+	adminService.HandleTokenBlock(w, req)
+
+	result := w.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.StatusCode)
+	}
+
+	if !adminService.server.IsTokenBlocked(token("basepath-block-token1")) {
+		t.Fatal("token should be blocked even with base path")
+	}
+}

--- a/tunnel/admin_service.go
+++ b/tunnel/admin_service.go
@@ -104,7 +104,7 @@ const (
 type TunnelEvent struct {
 	ID            int64     `json:"id"`
 	Token         string    `json:"token"`
-	Event         string    `json:"event"` // connected, disconnected, reaped, error
+	Event         string    `json:"event"` // connected, disconnected, reaped, error, force_disconnected, blocked, unblocked
 	RemoteAddr    string    `json:"remote_addr"`
 	RemoteName    string    `json:"remote_name"`
 	RemoteWhois   string    `json:"remote_whois"`
@@ -820,7 +820,7 @@ func (as *AdminService) HandleTunnelDisconnect(w http.ResponseWriter, r *http.Re
 		safeW.Header().Set("Content-Type", "application/json")
 		safeW.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(safeW).Encode(DisconnectResponse{
-			Token:        string(tok),
+			Token:        cutToken(tok),
 			Disconnected: 0,
 			Message:      "tunnel not found",
 		})
@@ -830,7 +830,7 @@ func (as *AdminService) HandleTunnelDisconnect(w http.ResponseWriter, r *http.Re
 	count := rs.CloseAllConnections()
 
 	if err := as.RecordTunnelEvent(r.Context(), string(tok), TunnelEventForceDisconnected,
-		"", "", "", "", fmt.Sprintf("admin force-disconnected %d connection(s)", count)); err != nil {
+		r.RemoteAddr, "", "", "", fmt.Sprintf("admin force-disconnected %d connection(s)", count)); err != nil {
 		as.log.Warn().Err(err).Msg("Failed to record force-disconnect event")
 	}
 
@@ -865,7 +865,7 @@ func (as *AdminService) HandleTokenBlock(w http.ResponseWriter, r *http.Request)
 		}
 
 		if err := as.RecordTunnelEvent(r.Context(), string(tok), TunnelEventBlocked,
-			"", "", "", "", "token blocked by admin"); err != nil {
+			r.RemoteAddr, "", "", "", "token blocked by admin"); err != nil {
 			as.log.Warn().Err(err).Msg("Failed to record block event")
 		}
 
@@ -887,7 +887,7 @@ func (as *AdminService) HandleTokenBlock(w http.ResponseWriter, r *http.Request)
 
 		if existed {
 			if err := as.RecordTunnelEvent(r.Context(), string(tok), TunnelEventUnblocked,
-				"", "", "", "", "token unblocked by admin"); err != nil {
+				r.RemoteAddr, "", "", "", "token unblocked by admin"); err != nil {
 				as.log.Warn().Err(err).Msg("Failed to record unblock event")
 			}
 		}

--- a/tunnel/admin_service.go
+++ b/tunnel/admin_service.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -90,10 +91,13 @@ type RequestEvent struct {
 }
 
 const (
-	TunnelEventConnected    = "connected"
-	TunnelEventDisconnected = "disconnected"
-	TunnelEventReaped       = "reaped"
-	TunnelEventError        = "error"
+	TunnelEventConnected         = "connected"
+	TunnelEventDisconnected      = "disconnected"
+	TunnelEventReaped            = "reaped"
+	TunnelEventError             = "error"
+	TunnelEventForceDisconnected = "force_disconnected"
+	TunnelEventBlocked           = "blocked"
+	TunnelEventUnblocked         = "unblocked"
 )
 
 // TunnelEvent represents a tunnel lifecycle event
@@ -122,6 +126,38 @@ type APIEndpoint struct {
 	Description string                 `json:"description"`
 	Response    map[string]interface{} `json:"response"`
 }
+
+// DisconnectResponse represents the JSON response for force-disconnect
+type DisconnectResponse struct {
+	Token        string `json:"token"`
+	Disconnected int    `json:"disconnected"`
+	Message      string `json:"message"`
+}
+
+// BlockResponse represents the JSON response for token blocking/unblocking
+type BlockResponse struct {
+	Token        string `json:"token"`
+	Blocked      bool   `json:"blocked"`
+	Disconnected int    `json:"disconnected,omitempty"`
+	Message      string `json:"message"`
+}
+
+// BlockedTokensResponse represents the JSON response for listing blocked tokens
+type BlockedTokensResponse struct {
+	Timestamp     time.Time          `json:"timestamp"`
+	BlockedTokens []BlockedTokenInfo `json:"blocked_tokens"`
+	Count         int                `json:"count"`
+}
+
+// BlockedTokenInfo represents a single blocked token entry
+type BlockedTokenInfo struct {
+	Token     string    `json:"token"`
+	BlockedAt time.Time `json:"blocked_at"`
+}
+
+// Regex patterns for admin control path parsing
+var matchTunnelDisconnect = regexp.MustCompile(`^/admin/tunnels/([^/]+)/disconnect$`)
+var matchTokenBlock = regexp.MustCompile(`^/admin/tokens/([^/]+)/block$`)
 
 // NewAdminService creates a new admin service with SQLite tracking
 func NewAdminService(server *WSTunnelServer, dbPath string) (*AdminService, error) {
@@ -669,6 +705,68 @@ func (as *AdminService) GetAPIDocumentation() *APIDocsResponse {
 					},
 				},
 			},
+			{
+				Path:        "/admin/tunnels/{token}/disconnect",
+				Method:      "POST",
+				Description: "Force-disconnect all WebSocket connections for a given token",
+				Response: map[string]interface{}{
+					"token": map[string]string{
+						"type":        "string",
+						"description": "Truncated token identifier",
+					},
+					"disconnected": map[string]string{
+						"type":        "integer",
+						"description": "Number of connections that were disconnected",
+					},
+					"message": map[string]string{
+						"type":        "string",
+						"description": "Human-readable result message",
+					},
+				},
+			},
+			{
+				Path:        "/admin/tokens/{token}/block",
+				Method:      "POST/DELETE",
+				Description: "Block (POST) or unblock (DELETE) a token. Blocked tokens cannot establish new connections. Use ?disconnect=true on POST to also force-disconnect existing connections.",
+				Response: map[string]interface{}{
+					"token": map[string]string{
+						"type":        "string",
+						"description": "Truncated token identifier",
+					},
+					"blocked": map[string]string{
+						"type":        "boolean",
+						"description": "Whether the token is now blocked",
+					},
+					"disconnected": map[string]string{
+						"type":        "integer",
+						"description": "Number of connections disconnected (only when ?disconnect=true)",
+					},
+					"message": map[string]string{
+						"type":        "string",
+						"description": "Human-readable result message",
+					},
+				},
+			},
+			{
+				Path:        "/admin/tokens/blocked",
+				Method:      "GET",
+				Description: "List all currently blocked tokens",
+				Response: map[string]interface{}{
+					"timestamp": map[string]string{
+						"type":        "string",
+						"format":      "datetime",
+						"description": "Time when the list was generated",
+					},
+					"blocked_tokens": map[string]string{
+						"type":        "array",
+						"description": "List of blocked tokens with their block timestamps",
+					},
+					"count": map[string]string{
+						"type":        "integer",
+						"description": "Total number of blocked tokens",
+					},
+				},
+			},
 		},
 	}
 }
@@ -689,4 +787,146 @@ func (as *AdminService) HandleAPIDocs(w http.ResponseWriter, r *http.Request) {
 		as.log.Error().Err(err).Msg("Failed to encode API docs response")
 		safeError(safeW, "Internal server error", http.StatusInternalServerError)
 	}
+}
+
+// stripBasePath removes the server base path prefix from a request path
+func (as *AdminService) stripBasePath(path string) string {
+	if as.server.BasePath != "" {
+		path = strings.TrimPrefix(path, as.server.BasePath)
+	}
+	return path
+}
+
+// HandleTunnelDisconnect handles POST /admin/tunnels/{token}/disconnect
+func (as *AdminService) HandleTunnelDisconnect(w http.ResponseWriter, r *http.Request) {
+	safeW := &safeResponseWriter{ResponseWriter: w}
+
+	if r.Method != "POST" {
+		safeError(safeW, "Only POST requests are supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	path := as.stripBasePath(r.URL.Path)
+	matches := matchTunnelDisconnect.FindStringSubmatch(path)
+	if len(matches) != 2 {
+		safeError(safeW, "Invalid path format, expected /admin/tunnels/{token}/disconnect", http.StatusBadRequest)
+		return
+	}
+
+	tok := token(matches[1])
+
+	rs := as.server.getRemoteServer(tok, false)
+	if rs == nil {
+		safeW.Header().Set("Content-Type", "application/json")
+		safeW.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(safeW).Encode(DisconnectResponse{
+			Token:        string(tok),
+			Disconnected: 0,
+			Message:      "tunnel not found",
+		})
+		return
+	}
+
+	count := rs.CloseAllConnections()
+
+	if err := as.RecordTunnelEvent(r.Context(), string(tok), TunnelEventForceDisconnected,
+		"", "", "", "", fmt.Sprintf("admin force-disconnected %d connection(s)", count)); err != nil {
+		as.log.Warn().Err(err).Msg("Failed to record force-disconnect event")
+	}
+
+	safeW.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(safeW).Encode(DisconnectResponse{
+		Token:        cutToken(tok),
+		Disconnected: count,
+		Message:      fmt.Sprintf("disconnected %d connection(s)", count),
+	})
+}
+
+// HandleTokenBlock handles POST/DELETE /admin/tokens/{token}/block
+func (as *AdminService) HandleTokenBlock(w http.ResponseWriter, r *http.Request) {
+	safeW := &safeResponseWriter{ResponseWriter: w}
+
+	path := as.stripBasePath(r.URL.Path)
+	matches := matchTokenBlock.FindStringSubmatch(path)
+	if len(matches) != 2 {
+		safeError(safeW, "Invalid path format, expected /admin/tokens/{token}/block", http.StatusBadRequest)
+		return
+	}
+
+	tok := token(matches[1])
+
+	switch r.Method {
+	case "POST":
+		as.server.BlockToken(tok)
+
+		var disconnected int
+		if r.URL.Query().Get("disconnect") == "true" {
+			disconnected = as.server.DisconnectToken(tok)
+		}
+
+		if err := as.RecordTunnelEvent(r.Context(), string(tok), TunnelEventBlocked,
+			"", "", "", "", "token blocked by admin"); err != nil {
+			as.log.Warn().Err(err).Msg("Failed to record block event")
+		}
+
+		msg := "token blocked"
+		if disconnected > 0 {
+			msg = fmt.Sprintf("token blocked, disconnected %d connection(s)", disconnected)
+		}
+
+		safeW.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(safeW).Encode(BlockResponse{
+			Token:        cutToken(tok),
+			Blocked:      true,
+			Disconnected: disconnected,
+			Message:      msg,
+		})
+
+	case "DELETE":
+		existed := as.server.UnblockToken(tok)
+
+		if existed {
+			if err := as.RecordTunnelEvent(r.Context(), string(tok), TunnelEventUnblocked,
+				"", "", "", "", "token unblocked by admin"); err != nil {
+				as.log.Warn().Err(err).Msg("Failed to record unblock event")
+			}
+		}
+
+		safeW.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(safeW).Encode(BlockResponse{
+			Token:   cutToken(tok),
+			Blocked: false,
+			Message: "token unblocked",
+		})
+
+	default:
+		safeError(safeW, "Only POST and DELETE requests are supported", http.StatusMethodNotAllowed)
+	}
+}
+
+// HandleBlockedTokens handles GET /admin/tokens/blocked
+func (as *AdminService) HandleBlockedTokens(w http.ResponseWriter, r *http.Request) {
+	safeW := &safeResponseWriter{ResponseWriter: w}
+
+	if r.Method != "GET" {
+		safeError(safeW, "Only GET requests are supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	blocked := as.server.GetBlockedTokens()
+
+	tokens := make([]BlockedTokenInfo, 0, len(blocked))
+	for tok, blockedAt := range blocked {
+		tokens = append(tokens, BlockedTokenInfo{
+			Token:     cutToken(tok),
+			BlockedAt: blockedAt,
+		})
+	}
+
+	safeW.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(safeW).Encode(BlockedTokensResponse{
+		Timestamp:     time.Now(),
+		BlockedTokens: tokens,
+		Count:         len(tokens),
+	})
 }

--- a/tunnel/admin_service_test.go
+++ b/tunnel/admin_service_test.go
@@ -41,6 +41,7 @@ func setupTestAdminService(t *testing.T) (*AdminService, func()) {
 		Log:            zerolog.New(os.Stderr).With().Str("pkg", "test").Logger(),
 		serverRegistry: make(map[token]*remoteServer),
 		tokenClients:   make(map[token]int),
+		blockedTokens:  make(map[token]time.Time),
 	}
 
 	// Create admin service
@@ -526,6 +527,7 @@ func TestHandleAPIDocs(t *testing.T) {
 		Log:            zerolog.New(os.Stderr).With().Str("pkg", "test").Logger(),
 		serverRegistry: make(map[token]*remoteServer),
 		tokenClients:   make(map[token]int),
+		blockedTokens:  make(map[token]time.Time),
 	}
 
 	// Create admin service
@@ -629,6 +631,7 @@ func TestHandleAdminUI(t *testing.T) {
 		Log:            zerolog.New(os.Stderr).With().Str("pkg", "test").Logger(),
 		serverRegistry: make(map[token]*remoteServer),
 		tokenClients:   make(map[token]int),
+		blockedTokens:  make(map[token]time.Time),
 	}
 
 	// Create admin service
@@ -711,6 +714,7 @@ func TestHandleAdminUIRedirect(t *testing.T) {
 		Log:            zerolog.New(os.Stderr).With().Str("pkg", "test").Logger(),
 		serverRegistry: make(map[token]*remoteServer),
 		tokenClients:   make(map[token]int),
+		blockedTokens:  make(map[token]time.Time),
 	}
 
 	// Create admin service
@@ -777,6 +781,7 @@ func TestGetAPIDocumentation(t *testing.T) {
 		Log:            zerolog.New(os.Stderr).With().Str("pkg", "test").Logger(),
 		serverRegistry: make(map[token]*remoteServer),
 		tokenClients:   make(map[token]int),
+		blockedTokens:  make(map[token]time.Time),
 	}
 
 	// Create admin service
@@ -807,8 +812,9 @@ func TestGetAPIDocumentation(t *testing.T) {
 		if endpoint.Path == "" {
 			t.Error("Endpoint path should not be empty")
 		}
-		if endpoint.Method != "GET" {
-			t.Errorf("Expected all endpoints to be GET, got %s", endpoint.Method)
+		validMethods := map[string]bool{"GET": true, "POST": true, "DELETE": true, "POST/DELETE": true}
+		if !validMethods[endpoint.Method] {
+			t.Errorf("Unexpected method %s for endpoint %s", endpoint.Method, endpoint.Path)
 		}
 		if endpoint.Description == "" {
 			t.Error("Endpoint description should not be empty")

--- a/tunnel/ws.go
+++ b/tunnel/ws.go
@@ -221,6 +221,16 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 	closeCh := make(chan struct{})
 	deregister := rs.RegisterConnection(closeCh)
 	defer deregister()
+	// Re-check block status after registration to close the race with admin
+	// BlockToken/DisconnectToken: a block applied between the initial check
+	// and registration could have signaled no connections; this catches that.
+	if t.IsTokenBlocked(tokenStr) {
+		t.Log.Info().Str("token", logTok).Str("ws", wsp(ws)).Msg("Token blocked during connection setup, closing")
+		if err := ws.Close(); err != nil {
+			t.Log.Warn().Err(err).Msg("Failed to close websocket after late block detection")
+		}
+		return
+	}
 	// Start timeout handling
 	wsSetPingHandler(t, ws, rs)
 	// Create synchronization channel

--- a/tunnel/ws.go
+++ b/tunnel/ws.go
@@ -93,6 +93,12 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 	tokenStr := token(tok)
 	logTok := cutToken(tokenStr)
 
+	// Check if token is blocked
+	if t.IsTokenBlocked(tokenStr) {
+		httpError(t.Log, w, logTok, "Token is blocked", 403)
+		return
+	}
+
 	// Check if password is required for this token
 	t.tokenPasswordsMutex.RLock()
 	expectedPassword, hasPassword := t.tokenPasswords[tokenStr]
@@ -211,6 +217,10 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 		name, whois := ipAddrLookup(t.Log, rs.remoteAddr)
 		rs.setRemoteInfo(name, whois)
 	}()
+	// Register connection for force-disconnect support
+	closeCh := make(chan struct{})
+	deregister := rs.RegisterConnection(closeCh)
+	defer deregister()
 	// Start timeout handling
 	wsSetPingHandler(t, ws, rs)
 	// Create synchronization channel
@@ -218,7 +228,7 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 	// Spawn goroutine to read responses
 	go wsReader(t, rs, ws, ch, tokenStr, addr)
 	// Send requests
-	wsWriter(rs, ws, ch)
+	wsWriter(rs, ws, ch, closeCh)
 }
 
 func wsSetPingHandler(t *WSTunnelServer, ws *websocket.Conn, rs *remoteServer) {
@@ -250,7 +260,7 @@ func wsSetPingHandler(t *WSTunnelServer, ws *websocket.Conn, rs *remoteServer) {
 }
 
 // Pick requests off the RemoteServer queue and send them into the tunnel
-func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int) {
+func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int, closeCh chan struct{}) {
 	var req *remoteRequest
 	var err error
 	for {
@@ -264,6 +274,15 @@ func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int) {
 			if err := ws.Close(); err != nil {
 				rs.log.Error().Err(err).Msg("Failed to close websocket")
 			}
+			return
+		case <-closeCh:
+			// force-disconnect from admin API
+			rs.log.Info().Str("ws", wsp(ws)).Msg("WS closing on admin force-disconnect")
+			_ = ws.WriteControl(websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseGoingAway, "force-disconnected by admin"),
+				time.Now().Add(5*time.Second))
+			time.Sleep(2 * time.Second)
+			_ = ws.Close()
 			return
 		}
 		// See whether the request has already expired

--- a/tunnel/wstunsrv.go
+++ b/tunnel/wstunsrv.go
@@ -457,7 +457,9 @@ func (t *WSTunnelServer) Start(listener net.Listener) {
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/monitoring"), t.adminService.HandleMonitoring)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/api-docs"), t.adminService.HandleAPIDocs)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/ui"), t.adminService.HandleAdminUI)
-		// Tunnel control endpoints (order matters: /admin/tokens/blocked before /admin/tokens/ for longest-prefix match)
+		// Tunnel control endpoints: ServeMux matches the most specific (longest)
+		// pattern, so /admin/tokens/blocked is preferred over /admin/tokens/
+		// regardless of registration order.
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/tunnels/"), t.adminService.HandleTunnelDisconnect)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/tokens/blocked"), t.adminService.HandleBlockedTokens)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/tokens/"), t.adminService.HandleTokenBlock)

--- a/tunnel/wstunsrv.go
+++ b/tunnel/wstunsrv.go
@@ -79,8 +79,10 @@ type remoteServer struct {
 	requestSet      map[int16]*remoteRequest // all requests in queue/flight indexed by ID
 	requestSetMutex sync.Mutex
 	log             zerolog.Logger
-	readMutex       sync.Mutex // ensure that no more than one goroutine calls the websocket read methods concurrently
-	readCond        *sync.Cond // (NextReader, SetReadDeadline, SetPingHandler, ...)
+	readMutex       sync.Mutex      // ensure that no more than one goroutine calls the websocket read methods concurrently
+	readCond        *sync.Cond      // (NextReader, SetReadDeadline, SetPingHandler, ...)
+	connCloseChans  []chan struct{} // close channels for each active WebSocket connection
+	connCloseMutex  sync.Mutex      // protects connCloseChans
 }
 
 // setClientVersion safely sets the client version
@@ -112,6 +114,43 @@ func (rs *remoteServer) getRemoteInfo() (name, whois string) {
 	return rs.remoteName, rs.remoteWhois
 }
 
+// RegisterConnection adds a close channel for a new WebSocket connection.
+// Returns a deregister function that must be called on disconnect.
+func (rs *remoteServer) RegisterConnection(closeCh chan struct{}) func() {
+	rs.connCloseMutex.Lock()
+	rs.connCloseChans = append(rs.connCloseChans, closeCh)
+	rs.connCloseMutex.Unlock()
+
+	return func() {
+		rs.connCloseMutex.Lock()
+		defer rs.connCloseMutex.Unlock()
+		for i, ch := range rs.connCloseChans {
+			if ch == closeCh {
+				rs.connCloseChans = append(rs.connCloseChans[:i], rs.connCloseChans[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+// CloseAllConnections signals all active WebSocket connections to close gracefully.
+// Returns the number of connections signaled.
+func (rs *remoteServer) CloseAllConnections() int {
+	rs.connCloseMutex.Lock()
+	defer rs.connCloseMutex.Unlock()
+	count := len(rs.connCloseChans)
+	for _, ch := range rs.connCloseChans {
+		select {
+		case <-ch:
+			// already closed
+		default:
+			close(ch)
+		}
+	}
+	rs.connCloseChans = nil
+	return count
+}
+
 // WSTunnelServer a wstunnel server construct
 type WSTunnelServer struct {
 	Port                 int                     // port to listen on
@@ -131,12 +170,59 @@ type WSTunnelServer struct {
 	tokenClientsMutex    sync.RWMutex            // mutex to protect client count map
 	adminService         *AdminService           // admin service for monitoring and auditing
 	adminServiceMutex    sync.RWMutex            // mutex to protect admin service access
+	blockedTokens        map[token]time.Time     // in-memory blocklist of tokens with block timestamp
+	blockedTokensMutex   sync.RWMutex            // mutex to protect blockedTokens
 }
 
 func (t *WSTunnelServer) getAdminService() *AdminService {
 	t.adminServiceMutex.RLock()
 	defer t.adminServiceMutex.RUnlock()
 	return t.adminService
+}
+
+// IsTokenBlocked checks if a token is in the blocklist
+func (t *WSTunnelServer) IsTokenBlocked(tok token) bool {
+	t.blockedTokensMutex.RLock()
+	defer t.blockedTokensMutex.RUnlock()
+	_, blocked := t.blockedTokens[tok]
+	return blocked
+}
+
+// BlockToken adds a token to the in-memory blocklist
+func (t *WSTunnelServer) BlockToken(tok token) {
+	t.blockedTokensMutex.Lock()
+	defer t.blockedTokensMutex.Unlock()
+	t.blockedTokens[tok] = time.Now()
+}
+
+// UnblockToken removes a token from the blocklist. Returns true if the token was blocked.
+func (t *WSTunnelServer) UnblockToken(tok token) bool {
+	t.blockedTokensMutex.Lock()
+	defer t.blockedTokensMutex.Unlock()
+	_, existed := t.blockedTokens[tok]
+	delete(t.blockedTokens, tok)
+	return existed
+}
+
+// GetBlockedTokens returns a copy of the blocked tokens map
+func (t *WSTunnelServer) GetBlockedTokens() map[token]time.Time {
+	t.blockedTokensMutex.RLock()
+	defer t.blockedTokensMutex.RUnlock()
+	result := make(map[token]time.Time, len(t.blockedTokens))
+	for k, v := range t.blockedTokens {
+		result[k] = v
+	}
+	return result
+}
+
+// DisconnectToken force-disconnects all WebSocket connections for a token.
+// Returns the number of connections disconnected.
+func (t *WSTunnelServer) DisconnectToken(tok token) int {
+	rs := t.getRemoteServer(tok, false)
+	if rs == nil {
+		return 0
+	}
+	return rs.CloseAllConnections()
 }
 
 // name Lookups
@@ -259,6 +345,9 @@ func NewWSTunnelServer(args []string) *WSTunnelServer {
 	// Initialize token client count map
 	wstunSrv.tokenClients = make(map[token]int)
 
+	// Initialize token blocklist
+	wstunSrv.blockedTokens = make(map[token]time.Time)
+
 	// Parse token passwords
 	wstunSrv.tokenPasswords = make(map[token]string)
 	if *tokenPass != "" {
@@ -368,6 +457,10 @@ func (t *WSTunnelServer) Start(listener net.Listener) {
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/monitoring"), t.adminService.HandleMonitoring)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/api-docs"), t.adminService.HandleAPIDocs)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/ui"), t.adminService.HandleAdminUI)
+		// Tunnel control endpoints (order matters: /admin/tokens/blocked before /admin/tokens/ for longest-prefix match)
+		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/tunnels/"), t.adminService.HandleTunnelDisconnect)
+		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/tokens/blocked"), t.adminService.HandleBlockedTokens)
+		httpMux.HandleFunc(buildPath(t.BasePath, "/admin/tokens/"), t.adminService.HandleTokenBlock)
 		httpMux.HandleFunc(buildPath(t.BasePath, "/admin"), t.adminService.HandleAdminUIRedirect)
 	}
 	t.adminServiceMutex.RUnlock()
@@ -875,11 +968,12 @@ func (t *WSTunnelServer) getRemoteServer(tok token, create bool) *remoteServer {
 		maxRequests = 1000
 	}
 	rs = &remoteServer{
-		token:        tok,
-		lastActivity: time.Now(),
-		requestQueue: make(chan *remoteRequest, maxRequests),
-		requestSet:   make(map[int16]*remoteRequest),
-		log:          t.Log.With().Str("token", cutToken(tok)).Logger(),
+		token:          tok,
+		lastActivity:   time.Now(),
+		requestQueue:   make(chan *remoteRequest, maxRequests),
+		requestSet:     make(map[int16]*remoteRequest),
+		connCloseChans: make([]chan struct{}, 0),
+		log:            t.Log.With().Str("token", cutToken(tok)).Logger(),
 	}
 	rs.readCond = sync.NewCond(&rs.readMutex)
 	t.serverRegistry[tok] = rs


### PR DESCRIPTION
…ocking

## Summary

- Adds runtime admin endpoints to manage tunnels without server restart: force-disconnect active clients and temporarily block tokens from establishing new connections
- Uses per-connection close channels to signal graceful WebSocket shutdown (CloseGoingAway frame) without concurrent write races on gorilla/websocket
- In-memory blocklist is stateless (lost on restart), matching the project's no-persistent-state design
- Block endpoint supports optional `?disconnect=true` query param to also force-close existing connections for the token

## Test plan

- [x] 24 new tests covering unit, handler, lifecycle, and base path scenarios
- [x] `make format` passes
- [x] `make lint` passes with zero issues
- [x] `make test` passes (all existing + new tests)
- [x] Coverage at 71.1% for tunnel package

## Changes

### New files

- `tunnel/admin_control_test.go` - Tests for connection tracking, token blocklist, admin handlers, and base path support

### Modified files

- `tunnel/wstunsrv.go` - Added `connCloseChans`/`connCloseMutex` to `remoteServer` for connection tracking, `blockedTokens`/`blockedTokensMutex` to `WSTunnelServer` for in-memory blocklist, methods for register/close connections and block/unblock tokens, and route registration for new endpoints
- `tunnel/ws.go` - Added token block check (HTTP 403) in `wsHandler()`, connection close channel registration, and `closeCh` parameter to `wsWriter()` with graceful close handling
- `tunnel/admin_service.go` - Added response types, event constants, regex patterns for path parsing, three new handlers (`HandleTunnelDisconnect`, `HandleTokenBlock`, `HandleBlockedTokens`), and API documentation entries
- `tunnel/admin_service_test.go` - Updated `setupTestAdminService` to initialize `blockedTokens` map, relaxed API docs test to accept non-GET methods

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block/unblock tunnel tokens to prevent new connections and immediately reject blocked attempts.
  * Force-disconnect to terminate active tunnel connections (optionally when blocking).
  * Endpoint to list currently blocked tokens.
  * Admin endpoints and event tracking for disconnect, block, and unblock actions (work with configured base path).

* **Tests**
  * Comprehensive test coverage for admin controls, token blocking, disconnects, handler behavior, lifecycle and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->